### PR TITLE
Add 5 more locales (vi/pt/es/de/fr), font subsets, and a language switcher

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -24,7 +24,7 @@ export default defineConfig({
   // a prefix (/id/, …). New locales get added to `locales` as translations land.
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'id'],
+    locales: ['en', 'id', 'vi', 'pt', 'es', 'de', 'fr'],
     routing: { prefixDefaultLocale: false },
   },
   // Inline all stylesheets into the HTML to remove the render-blocking CSS
@@ -40,7 +40,15 @@ export default defineConfig({
     sitemap({
       i18n: {
         defaultLocale: 'en',
-        locales: { en: 'en-US', id: 'id-ID' },
+        locales: {
+          en: 'en-US',
+          id: 'id-ID',
+          vi: 'vi-VN',
+          pt: 'pt-BR',
+          es: 'es-ES',
+          de: 'de-DE',
+          fr: 'fr-FR',
+        },
       },
     }),
     // Build-time SEO / accessibility / performance / GEO validation. Output is
@@ -75,7 +83,7 @@ export default defineConfig({
       cssVariable: '--font-fraunces',
       weights: [400, 500, 600],
       styles: ['normal', 'italic'],
-      subsets: ['latin'],
+      subsets: ['latin', 'latin-ext', 'vietnamese'],
       fallbacks: ['Georgia', 'serif'],
       display: 'swap',
     },
@@ -85,7 +93,7 @@ export default defineConfig({
       cssVariable: '--font-hanken',
       weights: [400, 500, 600, 700],
       styles: ['normal'],
-      subsets: ['latin'],
+      subsets: ['latin', 'latin-ext', 'vietnamese'],
       fallbacks: ['system-ui', 'sans-serif'],
       display: 'swap',
     },
@@ -95,7 +103,7 @@ export default defineConfig({
       cssVariable: '--font-jetbrains',
       weights: [400, 500, 700],
       styles: ['normal'],
-      subsets: ['latin'],
+      subsets: ['latin', 'latin-ext', 'vietnamese'],
       fallbacks: ['ui-monospace', 'monospace'],
       display: 'swap',
     },

--- a/src/__tests__/e2e/i18n.spec.ts
+++ b/src/__tests__/e2e/i18n.spec.ts
@@ -77,4 +77,44 @@ test.describe('Internationalization', () => {
       0,
     );
   });
+
+  test('Vietnamese home renders translated content at /vi/', async ({
+    page,
+  }) => {
+    await page.goto('http://localhost:8080/vi/');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'vi');
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      'href',
+      'https://word2md.com/vi/',
+    );
+    await expect(page.getByText('Câu hỏi thường gặp')).toBeVisible();
+  });
+
+  test('language switcher lists every locale by endonym and marks the current one', async ({
+    page,
+  }) => {
+    await page.goto('http://localhost:8080/');
+    const switcher = page.locator('nav[aria-label="Language"]');
+    await expect(switcher).toBeVisible();
+
+    // Endonyms, no flags. The current locale is a non-link with aria-current.
+    await expect(switcher.locator('[aria-current="page"]')).toHaveText(
+      'English',
+    );
+    for (const endonym of [
+      'Bahasa Indonesia',
+      'Tiếng Việt',
+      'Português',
+      'Español',
+      'Deutsch',
+      'Français',
+    ]) {
+      await expect(switcher.getByRole('link', { name: endonym })).toBeVisible();
+    }
+
+    // Switching navigates to the localized home.
+    await switcher.getByRole('link', { name: 'Tiếng Việt' }).click();
+    await expect(page).toHaveURL('http://localhost:8080/vi/');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'vi');
+  });
 });

--- a/web/components/Home.astro
+++ b/web/components/Home.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import { asLocale, localeMeta, useTranslations, getAlternates } from '../i18n';
+import { asLocale, localeMeta, useTranslations } from '../i18n';
 // The promo banner is home-only, so its CSS stays here. Dark-mode theming and
 // the Tailwind layer live in the Layout's global.css. The browser logic is
 // imported via the <script> at the end, bundled through Astro's Vite pipeline.
@@ -14,10 +14,6 @@ interface Props {
 const locale = asLocale(Astro.props.lang);
 const meta = localeMeta[locale];
 const t = useTranslations(locale);
-
-// hreflang cluster — the home page exists in every locale, so it gets the full
-// self-referential set (en + id + x-default).
-const alternates = getAlternates('/');
 
 // Structured data (schema.org) for rich results: the app entity + the FAQ.
 // `inLanguage` and the human-readable copy follow the active locale.
@@ -71,7 +67,7 @@ const stepIcons = [
   title={t.metaTitle}
   description={t.metaDescription}
   structuredData={structuredData}
-  alternates={alternates}
+  i18nPath="/"
 >
   <!-- ── Hero ─────────────────────────────────────────────────────────── -->
   <section class="mx-auto max-w-3xl pt-14 pb-2 text-center sm:pt-20">

--- a/web/i18n/de.ts
+++ b/web/i18n/de.ts
@@ -1,0 +1,90 @@
+import type { UIStrings } from './types';
+
+// German (Deutsch).
+// Machine-translated first pass — flagged for native review before launch.
+// Google Docs menu labels follow the localized German UI (Datei → Herunterladen).
+export const de: UIStrings = {
+  eyebrow: 'Kostenlos · Open Source · 100% im Browser',
+  tagline:
+    'Wandle Word-Dateien (.docx) in sauberes Markdown um — komplett in deinem Browser. Deine Dateien werden nie hochgeladen.',
+
+  flowFromAlt: 'Word-Dokument',
+  flowToAlt: 'Markdown-Datei',
+
+  dropzoneTitle: 'Lege deine .docx hier ab',
+  dropzoneBrowsePrefix: 'oder ',
+  dropzoneBrowseLink: 'klicke, um eine Datei zu wählen',
+  googleDocHint: 'Google Doc? Datei → Herunterladen → Microsoft Word (.docx)',
+  convertSectionAria: 'Dokument umwandeln',
+
+  convertedLabel: 'Umgewandelt',
+  copyButton: 'Markdown kopieren',
+  downloadButton: '.md herunterladen',
+  panelMarkdown: 'Markdown',
+  panelPreview: 'Vorschau',
+
+  steps: [
+    {
+      t: 'Hochladen',
+      d: 'Ziehe eine .docx-Datei hinein oder klicke zum Auswählen.',
+    },
+    {
+      t: 'Umwandeln',
+      d: 'Die Umwandlung erfolgt im Browser — kein Server, kein Warten.',
+    },
+    {
+      t: 'Kopieren oder speichern',
+      d: 'Kopiere das Markdown oder lade eine .md-Datei herunter.',
+    },
+  ],
+
+  faqHeading: 'Häufig gestellte Fragen',
+  faqs: [
+    {
+      q: 'Wie wandle ich ein Word-Dokument in Markdown um?',
+      a: 'Ziehe eine .docx-Datei auf die Seite (oder klicke zum Auswählen). Word to Markdown wandelt sie im Browser um und zeigt das Markdown sofort an — kopiere es oder lade eine .md-Datei herunter.',
+    },
+    {
+      q: 'Ist Word to Markdown kostenlos?',
+      a: 'Ja. Es ist völlig kostenlos und Open Source — ohne Anmeldung, ohne Dateigrößenbeschränkung und ohne Werbung.',
+    },
+    {
+      q: 'Werden meine Dokumente auf einen Server hochgeladen?',
+      a: 'Nein. Die Umwandlung erfolgt vollständig in deinem Browser mit JavaScript. Deine Dateien verlassen nie dein Gerät und werden nie hochgeladen, gespeichert oder protokolliert.',
+    },
+    {
+      q: 'Wie wandle ich ein Google Doc in Markdown um?',
+      a: 'Wähle in Google Docs Datei → Herunterladen → Microsoft Word (.docx) und ziehe diese .docx in Word to Markdown.',
+    },
+    {
+      q: 'Welche Formatierung bleibt erhalten?',
+      a: 'Überschriften, fetter und kursiver Text, geordnete und verschachtelte Listen, Tabellen, Links und Code werden in sauberes Markdown im GitHub-Stil umgewandelt.',
+    },
+  ],
+
+  footer: {
+    feedback: 'Feedback',
+    source: 'Quellcode',
+    donate: 'Spenden',
+    terms: 'Nutzungsbedingungen',
+    privacy: 'Datenschutz',
+  },
+  footerTagline: 'Im Browser umgewandelt · nichts wird hochgeladen',
+  homeAria: 'Word to Markdown — Startseite',
+
+  metaTitle: 'Word to Markdown — Kostenloser .docx-zu-Markdown-Konverter',
+  metaDescription:
+    'Wandle Word (.docx) und Google Docs in sauberes Markdown im GitHub-Stil um — kostenlos, Open Source und komplett im Browser.',
+  schemaDescription:
+    'Kostenloses Open-Source-Tool, das Word (.docx) und Google Docs vollständig im Browser in sauberes Markdown im GitHub-Stil umwandelt.',
+  schemaFeatureList: [
+    'Word (.docx) in Markdown umwandeln',
+    'Google Docs in Markdown umwandeln',
+    'Markdown-Ausgabe im GitHub-Stil',
+    '100% clientseitig — nichts wird hochgeladen',
+  ],
+
+  errorGeneric:
+    'Beim Umwandeln des Dokuments ist ein unerwarteter Fehler aufgetreten. Bitte versuche es erneut.',
+  dismiss: 'Schließen',
+};

--- a/web/i18n/es.ts
+++ b/web/i18n/es.ts
@@ -1,0 +1,87 @@
+import type { UIStrings } from './types';
+
+// Spanish (Español).
+// Machine-translated first pass — flagged for native review before launch.
+// Google Docs menu labels follow the localized Spanish UI (Archivo → Descargar).
+export const es: UIStrings = {
+  eyebrow: 'Gratis · Código abierto · 100% en tu navegador',
+  tagline:
+    'Convierte archivos Word (.docx) en Markdown limpio — totalmente en tu navegador. Tus archivos nunca se suben.',
+
+  flowFromAlt: 'Documento de Word',
+  flowToAlt: 'Archivo Markdown',
+
+  dropzoneTitle: 'Suelta tu .docx aquí',
+  dropzoneBrowsePrefix: 'o ',
+  dropzoneBrowseLink: 'haz clic para elegir un archivo',
+  googleDocHint: '¿Google Doc? Archivo → Descargar → Microsoft Word (.docx)',
+  convertSectionAria: 'Convertir un documento',
+
+  convertedLabel: 'Convertido',
+  copyButton: 'Copiar Markdown',
+  downloadButton: 'Descargar .md',
+  panelMarkdown: 'Markdown',
+  panelPreview: 'Vista previa',
+
+  steps: [
+    { t: 'Subir', d: 'Arrastra un archivo .docx o haz clic para elegir uno.' },
+    {
+      t: 'Convertir',
+      d: 'Se convierte en tu navegador: sin servidor, sin esperas.',
+    },
+    {
+      t: 'Copiar o guardar',
+      d: 'Copia el Markdown o descarga un archivo .md.',
+    },
+  ],
+
+  faqHeading: 'Preguntas frecuentes',
+  faqs: [
+    {
+      q: '¿Cómo convierto un documento de Word a Markdown?',
+      a: 'Arrastra un archivo .docx a la página (o haz clic para seleccionarlo). Word to Markdown lo convierte en tu navegador y muestra el Markdown al instante: cópialo o descarga un archivo .md.',
+    },
+    {
+      q: '¿Word to Markdown es gratis?',
+      a: 'Sí. Es completamente gratis y de código abierto: sin registro, sin límite de tamaño de archivo y sin anuncios.',
+    },
+    {
+      q: '¿Mis documentos se suben a un servidor?',
+      a: 'No. La conversión ocurre totalmente en tu navegador con JavaScript. Tus archivos nunca salen de tu dispositivo y nunca se suben, almacenan ni registran.',
+    },
+    {
+      q: '¿Cómo convierto un Documento de Google a Markdown?',
+      a: 'En Google Docs, elige Archivo → Descargar → Microsoft Word (.docx) y suelta ese .docx en Word to Markdown.',
+    },
+    {
+      q: '¿Qué formato se conserva?',
+      a: 'Los títulos, el texto en negrita y cursiva, las listas ordenadas y anidadas, las tablas, los enlaces y el código se convierten en Markdown limpio con formato de GitHub.',
+    },
+  ],
+
+  footer: {
+    feedback: 'Comentarios',
+    source: 'Código fuente',
+    donate: 'Donar',
+    terms: 'Términos',
+    privacy: 'Privacidad',
+  },
+  footerTagline: 'Convertido en tu navegador · no se sube nada',
+  homeAria: 'Word to Markdown — inicio',
+
+  metaTitle: 'Word to Markdown — Conversor gratuito de .docx a Markdown',
+  metaDescription:
+    'Convierte Word (.docx) y Documentos de Google en Markdown limpio con formato de GitHub: gratis, código abierto y totalmente en tu navegador.',
+  schemaDescription:
+    'Herramienta gratuita y de código abierto que convierte Word (.docx) y Documentos de Google en Markdown limpio con formato de GitHub, totalmente en tu navegador.',
+  schemaFeatureList: [
+    'Convertir Word (.docx) a Markdown',
+    'Convertir Documentos de Google a Markdown',
+    'Salida en Markdown con formato de GitHub',
+    '100% del lado del cliente: no se sube nada',
+  ],
+
+  errorGeneric:
+    'Ocurrió un error inesperado al convertir el documento. Inténtalo de nuevo.',
+  dismiss: 'Descartar',
+};

--- a/web/i18n/fr.ts
+++ b/web/i18n/fr.ts
@@ -1,0 +1,90 @@
+import type { UIStrings } from './types';
+
+// French (Français).
+// Machine-translated first pass — flagged for native review before launch.
+// Google Docs menu labels follow the localized French UI (Fichier → Télécharger).
+export const fr: UIStrings = {
+  eyebrow: 'Gratuit · Open source · 100% dans votre navigateur',
+  tagline:
+    'Convertissez des fichiers Word (.docx) en Markdown propre — entièrement dans votre navigateur. Vos fichiers ne sont jamais envoyés.',
+
+  flowFromAlt: 'Document Word',
+  flowToAlt: 'Fichier Markdown',
+
+  dropzoneTitle: 'Déposez votre .docx ici',
+  dropzoneBrowsePrefix: 'ou ',
+  dropzoneBrowseLink: 'cliquez pour choisir un fichier',
+  googleDocHint: 'Google Doc ? Fichier → Télécharger → Microsoft Word (.docx)',
+  convertSectionAria: 'Convertir un document',
+
+  convertedLabel: 'Converti',
+  copyButton: 'Copier le Markdown',
+  downloadButton: 'Télécharger .md',
+  panelMarkdown: 'Markdown',
+  panelPreview: 'Aperçu',
+
+  steps: [
+    {
+      t: 'Importer',
+      d: 'Glissez un fichier .docx, ou cliquez pour en choisir un.',
+    },
+    {
+      t: 'Convertir',
+      d: 'La conversion se fait dans votre navigateur — sans serveur, sans attente.',
+    },
+    {
+      t: 'Copier ou enregistrer',
+      d: 'Copiez le Markdown, ou téléchargez un fichier .md.',
+    },
+  ],
+
+  faqHeading: 'Questions fréquentes',
+  faqs: [
+    {
+      q: 'Comment convertir un document Word en Markdown ?',
+      a: 'Glissez un fichier .docx sur la page (ou cliquez pour le sélectionner). Word to Markdown le convertit dans votre navigateur et affiche le Markdown instantanément — copiez-le ou téléchargez un fichier .md.',
+    },
+    {
+      q: 'Word to Markdown est-il gratuit ?',
+      a: 'Oui. Il est entièrement gratuit et open source — sans inscription, sans limite de taille de fichier et sans publicité.',
+    },
+    {
+      q: 'Mes documents sont-ils envoyés à un serveur ?',
+      a: 'Non. La conversion a lieu entièrement dans votre navigateur avec JavaScript. Vos fichiers ne quittent jamais votre appareil et ne sont jamais envoyés, stockés ni enregistrés.',
+    },
+    {
+      q: 'Comment convertir un Google Doc en Markdown ?',
+      a: 'Dans Google Docs, choisissez Fichier → Télécharger → Microsoft Word (.docx), puis déposez ce .docx dans Word to Markdown.',
+    },
+    {
+      q: 'Quelle mise en forme est conservée ?',
+      a: 'Les titres, le texte en gras et en italique, les listes ordonnées et imbriquées, les tableaux, les liens et le code sont convertis en Markdown propre au format GitHub.',
+    },
+  ],
+
+  footer: {
+    feedback: 'Commentaires',
+    source: 'Code source',
+    donate: 'Faire un don',
+    terms: 'Conditions',
+    privacy: 'Confidentialité',
+  },
+  footerTagline: "Converti dans votre navigateur · rien n'est envoyé",
+  homeAria: 'Word to Markdown — accueil',
+
+  metaTitle: 'Word to Markdown — Convertisseur .docx vers Markdown gratuit',
+  metaDescription:
+    'Convertissez Word (.docx) et Google Docs en Markdown propre au format GitHub — gratuit, open source et entièrement dans votre navigateur.',
+  schemaDescription:
+    'Outil gratuit et open source qui convertit Word (.docx) et Google Docs en Markdown propre au format GitHub, entièrement dans votre navigateur.',
+  schemaFeatureList: [
+    'Convertir Word (.docx) en Markdown',
+    'Convertir Google Docs en Markdown',
+    'Sortie Markdown au format GitHub',
+    "100% côté client — rien n'est envoyé",
+  ],
+
+  errorGeneric:
+    "Une erreur inattendue s'est produite lors de la conversion du document. Veuillez réessayer.",
+  dismiss: 'Fermer',
+};

--- a/web/i18n/index.ts
+++ b/web/i18n/index.ts
@@ -55,33 +55,9 @@ export function useTranslations(locale: string | undefined): UIStrings {
   return dictionaries[asLocale(locale)];
 }
 
-// Root-relative path to a page in a given locale. The default locale lives at
-// the root (prefixDefaultLocale: false); others are prefixed with `/<locale>`.
-function localizedPath(locale: Locale, path: string): string {
-  const clean = path.startsWith('/') ? path : `/${path}`;
-  return locale === defaultLocale ? clean : `/${locale}${clean}`;
-}
-
-export interface Alternate {
-  /** hreflang value, e.g. "en", "id", or "x-default". */
-  hreflang: string;
-  /** Root-relative path; the Layout resolves it against `site` for an absolute URL. */
-  path: string;
-}
-
-// hreflang cluster for a page that exists in every locale. MUST be
-// self-referential — each localized page lists every locale plus x-default,
-// not just the *other* languages (the most common hreflang mistake). One
-// broken/404 alternate makes search engines discard the whole cluster, so only
-// call this for pages that genuinely have a version in every listed locale.
-export function getAlternates(path = '/'): Alternate[] {
-  const alternates: Alternate[] = locales.map((locale) => ({
-    hreflang: localeMeta[locale].htmlLang,
-    path: localizedPath(locale, path),
-  }));
-  alternates.push({
-    hreflang: 'x-default',
-    path: localizedPath(defaultLocale, path),
-  });
-  return alternates;
-}
+// Localized URL generation is handled by the `astro:i18n` helpers
+// (getRelativeLocaleUrl / getAbsoluteLocaleUrl) directly in the .astro layout,
+// so it always respects `base`, `trailingSlash`, and the routing config rather
+// than re-deriving paths here. The hreflang *cluster* is built in Layout.astro:
+// it MUST stay self-referential (every localized page lists all locales plus
+// x-default), so only flag a page as localized if it exists in every locale.

--- a/web/i18n/index.ts
+++ b/web/i18n/index.ts
@@ -1,27 +1,47 @@
 import type { UIStrings } from './types';
 import { en } from './en';
 import { id } from './id';
+import { vi } from './vi';
+import { pt } from './pt';
+import { es } from './es';
+import { de } from './de';
+import { fr } from './fr';
 
 export type { UIStrings, FaqEntry, Step } from './types';
 
 // Locales that have a full translation. Keep in sync with astro.config.mjs
 // (both the top-level `i18n` block and the sitemap `i18n` block).
-export const locales = ['en', 'id'] as const;
+export const locales = ['en', 'id', 'vi', 'pt', 'es', 'de', 'fr'] as const;
 export type Locale = (typeof locales)[number];
 
 export const defaultLocale: Locale = 'en';
 
 // Per-locale metadata used in <head>. `name` is the endonym (the language's
 // own name) — used for the language switcher; never use flags for languages.
+// `htmlLang` doubles as the hreflang value; the locale key is the URL segment
+// (e.g. key `pt` → /pt/ with htmlLang/hreflang `pt-BR`).
 export const localeMeta: Record<
   Locale,
   { htmlLang: string; ogLocale: string; name: string }
 > = {
   en: { htmlLang: 'en', ogLocale: 'en_US', name: 'English' },
   id: { htmlLang: 'id', ogLocale: 'id_ID', name: 'Bahasa Indonesia' },
+  vi: { htmlLang: 'vi', ogLocale: 'vi_VN', name: 'Tiếng Việt' },
+  pt: { htmlLang: 'pt-BR', ogLocale: 'pt_BR', name: 'Português' },
+  es: { htmlLang: 'es', ogLocale: 'es_ES', name: 'Español' },
+  de: { htmlLang: 'de', ogLocale: 'de_DE', name: 'Deutsch' },
+  fr: { htmlLang: 'fr', ogLocale: 'fr_FR', name: 'Français' },
 };
 
-const dictionaries: Record<Locale, UIStrings> = { en, id };
+const dictionaries: Record<Locale, UIStrings> = {
+  en,
+  id,
+  vi,
+  pt,
+  es,
+  de,
+  fr,
+};
 
 /** Narrow an arbitrary string (e.g. Astro.currentLocale) to a known Locale. */
 export function asLocale(value: string | undefined): Locale {

--- a/web/i18n/pt.ts
+++ b/web/i18n/pt.ts
@@ -1,0 +1,85 @@
+import type { UIStrings } from './types';
+
+// Portuguese (Brazilian, pt-BR).
+// Machine-translated first pass — flagged for native review before launch.
+// Google Docs menu labels follow the localized Brazilian UI (Arquivo → Fazer download).
+export const pt: UIStrings = {
+  eyebrow: 'Grátis · Código aberto · 100% no seu navegador',
+  tagline:
+    'Converta arquivos Word (.docx) em Markdown limpo — inteiramente no seu navegador. Seus arquivos nunca são enviados.',
+
+  flowFromAlt: 'Documento Word',
+  flowToAlt: 'Arquivo Markdown',
+
+  dropzoneTitle: 'Solte seu .docx aqui',
+  dropzoneBrowsePrefix: 'ou ',
+  dropzoneBrowseLink: 'clique para escolher um arquivo',
+  googleDocHint:
+    'Google Doc? Arquivo → Fazer download → Microsoft Word (.docx)',
+  convertSectionAria: 'Converter um documento',
+
+  convertedLabel: 'Convertido',
+  copyButton: 'Copiar Markdown',
+  downloadButton: 'Baixar .md',
+  panelMarkdown: 'Markdown',
+  panelPreview: 'Visualização',
+
+  steps: [
+    { t: 'Enviar', d: 'Arraste um arquivo .docx ou clique para escolher.' },
+    {
+      t: 'Converter',
+      d: 'A conversão acontece no seu navegador — sem servidor, sem espera.',
+    },
+    { t: 'Copiar ou salvar', d: 'Copie o Markdown ou baixe um arquivo .md.' },
+  ],
+
+  faqHeading: 'Perguntas frequentes',
+  faqs: [
+    {
+      q: 'Como converter um documento Word em Markdown?',
+      a: 'Arraste um arquivo .docx para a página (ou clique para selecionar). O Word to Markdown converte no seu navegador e mostra o Markdown na hora — copie ou baixe um arquivo .md.',
+    },
+    {
+      q: 'O Word to Markdown é gratuito?',
+      a: 'Sim. É totalmente gratuito e de código aberto — sem cadastro, sem limite de tamanho de arquivo e sem anúncios.',
+    },
+    {
+      q: 'Meus documentos são enviados para um servidor?',
+      a: 'Não. A conversão acontece inteiramente no seu navegador usando JavaScript. Seus arquivos nunca saem do seu dispositivo e nunca são enviados, armazenados ou registrados.',
+    },
+    {
+      q: 'Como converter um Google Doc em Markdown?',
+      a: 'No Google Docs, escolha Arquivo → Fazer download → Microsoft Word (.docx) e solte esse .docx no Word to Markdown.',
+    },
+    {
+      q: 'Qual formatação é preservada?',
+      a: 'Títulos, texto em negrito e itálico, listas ordenadas e aninhadas, tabelas, links e código são convertidos em Markdown limpo no padrão GitHub.',
+    },
+  ],
+
+  footer: {
+    feedback: 'Feedback',
+    source: 'Código-fonte',
+    donate: 'Doar',
+    terms: 'Termos',
+    privacy: 'Privacidade',
+  },
+  footerTagline: 'Convertido no seu navegador · nada é enviado',
+  homeAria: 'Word to Markdown — início',
+
+  metaTitle: 'Word to Markdown — Conversor de .docx para Markdown grátis',
+  metaDescription:
+    'Converta Word (.docx) e Google Docs em Markdown limpo no padrão GitHub — grátis, código aberto e totalmente no seu navegador.',
+  schemaDescription:
+    'Ferramenta gratuita e de código aberto que converte Word (.docx) e Google Docs em Markdown limpo no padrão GitHub, inteiramente no seu navegador.',
+  schemaFeatureList: [
+    'Converter Word (.docx) em Markdown',
+    'Converter Google Docs em Markdown',
+    'Saída em Markdown no padrão GitHub',
+    '100% no cliente — nada é enviado',
+  ],
+
+  errorGeneric:
+    'Ocorreu um erro inesperado ao converter o documento. Tente novamente.',
+  dismiss: 'Dispensar',
+};

--- a/web/i18n/vi.ts
+++ b/web/i18n/vi.ts
@@ -1,0 +1,85 @@
+import type { UIStrings } from './types';
+
+// Vietnamese (Tiếng Việt).
+// Machine-translated first pass — flagged for native review before launch.
+// Google Docs menu labels follow the localized Vietnamese UI (Tệp → Tải xuống).
+export const vi: UIStrings = {
+  eyebrow: 'Miễn phí · Mã nguồn mở · 100% trong trình duyệt',
+  tagline:
+    'Chuyển đổi tệp Word (.docx) sang Markdown gọn gàng — hoàn toàn trong trình duyệt của bạn. Tệp của bạn không bao giờ được tải lên.',
+
+  flowFromAlt: 'Tài liệu Word',
+  flowToAlt: 'Tệp Markdown',
+
+  dropzoneTitle: 'Thả tệp .docx của bạn vào đây',
+  dropzoneBrowsePrefix: 'hoặc ',
+  dropzoneBrowseLink: 'nhấp để chọn tệp',
+  googleDocHint: 'Google Doc? Tệp → Tải xuống → Microsoft Word (.docx)',
+  convertSectionAria: 'Chuyển đổi tài liệu',
+
+  convertedLabel: 'Đã chuyển đổi',
+  copyButton: 'Sao chép Markdown',
+  downloadButton: 'Tải .md',
+  panelMarkdown: 'Markdown',
+  panelPreview: 'Xem trước',
+
+  steps: [
+    { t: 'Tải lên', d: 'Kéo tệp .docx vào, hoặc nhấp để chọn.' },
+    {
+      t: 'Chuyển đổi',
+      d: 'Chuyển đổi ngay trong trình duyệt — không máy chủ, không chờ đợi.',
+    },
+    { t: 'Sao chép hoặc lưu', d: 'Sao chép Markdown, hoặc tải tệp .md.' },
+  ],
+
+  faqHeading: 'Câu hỏi thường gặp',
+  faqs: [
+    {
+      q: 'Làm cách nào để chuyển đổi tài liệu Word sang Markdown?',
+      a: 'Kéo tệp .docx vào trang (hoặc nhấp để chọn). Word to Markdown chuyển đổi ngay trong trình duyệt của bạn và hiển thị Markdown tức thì — sao chép hoặc tải xuống tệp .md.',
+    },
+    {
+      q: 'Word to Markdown có miễn phí không?',
+      a: 'Có. Hoàn toàn miễn phí và mã nguồn mở — không cần đăng ký, không giới hạn dung lượng tệp, và không quảng cáo.',
+    },
+    {
+      q: 'Tài liệu của tôi có được tải lên máy chủ không?',
+      a: 'Không. Việc chuyển đổi diễn ra hoàn toàn trong trình duyệt của bạn bằng JavaScript. Tệp của bạn không bao giờ rời khỏi thiết bị và không bao giờ được tải lên, lưu trữ hay ghi lại.',
+    },
+    {
+      q: 'Làm cách nào để chuyển đổi Google Doc sang Markdown?',
+      a: 'Trong Google Docs, chọn Tệp → Tải xuống → Microsoft Word (.docx), rồi thả tệp .docx đó vào Word to Markdown.',
+    },
+    {
+      q: 'Những định dạng nào được giữ lại?',
+      a: 'Tiêu đề, chữ in đậm và in nghiêng, danh sách có thứ tự và lồng nhau, bảng, liên kết, và mã được chuyển thành Markdown gọn gàng theo chuẩn GitHub.',
+    },
+  ],
+
+  footer: {
+    feedback: 'Phản hồi',
+    source: 'Mã nguồn',
+    donate: 'Ủng hộ',
+    terms: 'Điều khoản',
+    privacy: 'Quyền riêng tư',
+  },
+  footerTagline:
+    'Chuyển đổi trong trình duyệt của bạn · không có gì được tải lên',
+  homeAria: 'Word to Markdown — trang chủ',
+
+  metaTitle: 'Word to Markdown — Chuyển .docx sang Markdown miễn phí',
+  metaDescription:
+    'Chuyển đổi Word (.docx) và Google Docs sang Markdown chuẩn GitHub — miễn phí, mã nguồn mở, hoàn toàn trong trình duyệt của bạn.',
+  schemaDescription:
+    'Công cụ miễn phí, mã nguồn mở giúp chuyển đổi Word (.docx) và Google Docs sang Markdown chuẩn GitHub gọn gàng, hoàn toàn trong trình duyệt của bạn.',
+  schemaFeatureList: [
+    'Chuyển Word (.docx) sang Markdown',
+    'Chuyển Google Docs sang Markdown',
+    'Kết quả Markdown chuẩn GitHub',
+    '100% phía máy khách — không có gì được tải lên',
+  ],
+
+  errorGeneric:
+    'Đã xảy ra lỗi không mong muốn khi chuyển đổi tài liệu. Vui lòng thử lại.',
+  dismiss: 'Đóng',
+};

--- a/web/layouts/Layout.astro
+++ b/web/layouts/Layout.astro
@@ -8,13 +8,13 @@
 //     and each footer href appears exactly once (Playwright locators are strict).
 import '../styles/global.css';
 import { Font } from 'astro:assets';
+import { getAbsoluteLocaleUrl, getRelativeLocaleUrl } from 'astro:i18n';
 import {
   asLocale,
   defaultLocale,
   localeMeta,
   useTranslations,
   locales,
-  type Alternate,
 } from '../i18n';
 
 interface Props {
@@ -23,11 +23,12 @@ interface Props {
   image?: string;
   structuredData?: Record<string, unknown>;
   /**
-   * hreflang cluster for this page. Only pass it for pages that genuinely have
-   * a version in every locale (the home page) — passing it for an English-only
-   * page would advertise localized URLs that 404. Omit → no hreflang emitted.
+   * Unlocalized path of this page (e.g. "/") when it exists in EVERY locale —
+   * triggers a self-referential hreflang cluster. Only set it for fully
+   * translated pages (the home page); an English-only page would otherwise
+   * advertise localized URLs that 404. Omit → no hreflang emitted.
    */
-  alternates?: Alternate[];
+  i18nPath?: string;
 }
 
 // `.astro` pages pass props directly; Markdown pages using `layout:` pass
@@ -37,7 +38,7 @@ const {
   description = 'Convert Word or Google documents to Markdown online',
   image = '/og.png',
   structuredData,
-  alternates,
+  i18nPath,
 } = Astro.props.frontmatter ?? Astro.props;
 
 // Current locale drives the <html lang>, og:locale, and localized chrome.
@@ -50,24 +51,36 @@ const t = useTranslations(locale);
 const canonical = new URL(Astro.url.pathname, Astro.site).href;
 const ogImage = new URL(image, Astro.site).href;
 
-// Resolve hreflang alternates to absolute URLs.
-const hreflangs = (alternates ?? []).map((a) => ({
-  hreflang: a.hreflang,
-  href: new URL(a.path, Astro.site).href,
-}));
+// Self-referential hreflang cluster, emitted only for fully translated pages.
+// `getAbsoluteLocaleUrl` respects base/trailingSlash/routing config, so each
+// href stays in sync with how the route is actually generated. x-default points
+// at the default locale's URL.
+const hreflangs =
+  i18nPath === undefined
+    ? []
+    : [
+        ...locales.map((l) => ({
+          hreflang: localeMeta[l].htmlLang,
+          href: getAbsoluteLocaleUrl(l, i18nPath),
+        })),
+        {
+          hreflang: 'x-default',
+          href: getAbsoluteLocaleUrl(defaultLocale, i18nPath),
+        },
+      ];
 const ogLocaleAlternates = locales
   .filter((l) => l !== locale)
   .map((l) => localeMeta[l].ogLocale);
 
 // Locale-aware home link so visitors stay within their language.
-const homeHref = locale === defaultLocale ? '/' : `/${locale}/`;
+const homeHref = getRelativeLocaleUrl(locale, '/');
 
 // Language switcher: one real <a> per locale, labelled with the endonym (the
 // language's own name) — never a flag. Links to each locale's home (the only
 // translated page today); these crawlable links also aid locale discovery.
 const languageLinks = locales.map((l) => ({
   name: localeMeta[l].name,
-  href: l === defaultLocale ? '/' : `/${l}/`,
+  href: getRelativeLocaleUrl(l, '/'),
   current: l === locale,
 }));
 

--- a/web/layouts/Layout.astro
+++ b/web/layouts/Layout.astro
@@ -62,6 +62,15 @@ const ogLocaleAlternates = locales
 // Locale-aware home link so visitors stay within their language.
 const homeHref = locale === defaultLocale ? '/' : `/${locale}/`;
 
+// Language switcher: one real <a> per locale, labelled with the endonym (the
+// language's own name) — never a flag. Links to each locale's home (the only
+// translated page today); these crawlable links also aid locale discovery.
+const languageLinks = locales.map((l) => ({
+  name: localeMeta[l].name,
+  href: l === defaultLocale ? '/' : `/${l}/`,
+  current: l === locale,
+}));
+
 // Legal pages (Terms/Privacy) are English-only, so those links stay at the
 // root for every locale; external links are locale-independent.
 const footerLinks = [
@@ -148,6 +157,47 @@ const footerLinks = [
 
     <footer class="mx-auto mt-16 w-full max-w-5xl px-6 pb-10">
       <div class="rule mb-5"></div>
+      <nav
+        aria-label="Language"
+        class="mb-4 flex flex-wrap items-center justify-center gap-x-1 gap-y-1.5 text-[0.8rem]"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="mr-1.5 text-navy-soft/70 dark:text-mist/70"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M2 12h20" />
+          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+        </svg>
+        {
+          languageLinks.map((lang) =>
+            lang.current ? (
+              <span
+                aria-current="page"
+                class="rounded px-2 py-0.5 font-medium text-chartreuse-deep dark:text-chartreuse"
+              >
+                {lang.name}
+              </span>
+            ) : (
+              <a
+                href={lang.href}
+                class="rounded px-2 py-0.5 text-navy-soft underline decoration-transparent decoration-2 underline-offset-4 transition-colors hover:text-navy hover:decoration-chartreuse dark:text-mist dark:hover:text-white"
+              >
+                {lang.name}
+              </a>
+            ),
+          )
+        }
+      </nav>
       <nav
         class="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm"
       >

--- a/web/pages/de/index.astro
+++ b/web/pages/de/index.astro
@@ -1,0 +1,7 @@
+---
+// de home page, served at /de/. Markup is shared via the Home
+// component; this file just selects the locale.
+import Home from '../../components/Home.astro';
+---
+
+<Home lang="de" />

--- a/web/pages/es/index.astro
+++ b/web/pages/es/index.astro
@@ -1,0 +1,7 @@
+---
+// es home page, served at /es/. Markup is shared via the Home
+// component; this file just selects the locale.
+import Home from '../../components/Home.astro';
+---
+
+<Home lang="es" />

--- a/web/pages/fr/index.astro
+++ b/web/pages/fr/index.astro
@@ -1,0 +1,7 @@
+---
+// fr home page, served at /fr/. Markup is shared via the Home
+// component; this file just selects the locale.
+import Home from '../../components/Home.astro';
+---
+
+<Home lang="fr" />

--- a/web/pages/pt/index.astro
+++ b/web/pages/pt/index.astro
@@ -1,0 +1,7 @@
+---
+// pt home page, served at /pt/. Markup is shared via the Home
+// component; this file just selects the locale.
+import Home from '../../components/Home.astro';
+---
+
+<Home lang="pt" />

--- a/web/pages/vi/index.astro
+++ b/web/pages/vi/index.astro
@@ -1,0 +1,7 @@
+---
+// vi home page, served at /vi/. Markup is shared via the Home
+// component; this file just selects the locale.
+import Home from '../../components/Home.astro';
+---
+
+<Home lang="vi" />


### PR DESCRIPTION
**PR 2 of 3** in the internationalization plan. Builds on the en/id foundation (#158) by fanning out to the remaining priority languages and adding in-page language discovery.

## Locales
- Adds **Vietnamese, Portuguese (pt-BR), Spanish, German, French** — each a full `UIStrings` dictionary, so the type checker still enforces completeness. Machine-translated first pass, **flagged in each file for native review before launch.**
- Locale key = URL segment (`/pt/`) while `htmlLang`/`hreflang` carry the regional code (`pt-BR`).
- Wired into the i18n index, Astro `i18n` config, and the sitemap `i18n` block. Each localized home emits a complete self-referential hreflang cluster (7 locales + `x-default`), verified in built HTML.

## Fonts
- Adds `latin-ext` (de/es/fr/pt accents) and `vietnamese` subsets to all three brand fonts, so accented and Vietnamese glyphs render in-brand instead of falling back to system fonts. `unicode-range` keeps English downloads unaffected.

## Language switcher
- Footer switcher with one crawlable `<a>` per locale, labelled by **endonym** (the language's own name) — **never a flag**. Current locale is a non-link with `aria-current`. No JavaScript required; the links also aid locale discovery/crawl.

## Verification
- 116 unit + 19 e2e (incl. switcher navigation + Vietnamese specs) pass
- `npm run lint` clean, full build passes all checks for all 9 pages
- Rendering confirmed: Vietnamese diacritics + German umlauts, desktop and mobile

## Up next
- **PR3:** migrate GitHub Pages → Cloudflare Pages + edge `Accept-Language`/geo locale redirect (needs Cloudflare account + DNS access at cutover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)