### PR TITLE
Cloudflare Pages config + edge locale redirect (PR3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ dist/
 # Playwright test results
 test-results/
 playwright-report/
+# Cloudflare Wrangler / Pages local dev artifacts
+.wrangler/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,8 +7,10 @@ import tailwindcss from '@tailwindcss/vite';
 import sitemap from '@astrojs/sitemap';
 import checks from '@nuasite/checks';
 
-// The site is deployed to GitHub Pages at the custom domain word2md.com,
-// which serves from the root, so `base` stays `/`.
+// The site is deployed to Cloudflare Pages (migrated from GitHub Pages) at the
+// custom domain word2md.com, which serves from the root, so `base` stays `/`.
+// Output stays `static`; the only edge logic is a Pages Function at the repo
+// root (functions/index.js) that locale-redirects "/". See docs/cloudflare-migration.md.
 //
 // Astro owns `web/` (srcDir) so it never collides with `src/`, which is
 // owned exclusively by `tsc` for the library, CLI, and server.

--- a/docs/cloudflare-migration.md
+++ b/docs/cloudflare-migration.md
@@ -1,0 +1,82 @@
+# Migrating word2md.com to Cloudflare Pages
+
+This repo is preconfigured for Cloudflare Pages:
+
+- `wrangler.jsonc` — sets the build output dir (`dist`) and project name.
+- `functions/index.js` — an edge Function that locale-redirects `/` based on
+  `Accept-Language` (inert until deployed on Cloudflare Pages).
+- The site stays a static Astro build (`output: 'static'`); no SSR adapter.
+
+Everything below is done in the Cloudflare dashboard and your DNS — there's no
+more code to write. The steps are ordered so the live site never breaks: you
+stand up Cloudflare in parallel, verify it on its `*.pages.dev` URL, and only
+then move the domain.
+
+## 1. Create the Pages project (no DNS change yet)
+
+1. Sign up at <https://dash.cloudflare.com> (free).
+2. **Workers & Pages → Create → Pages → Connect to Git**, authorize GitHub, and
+   pick `benbalter/word-to-markdown-js`.
+3. Build settings:
+   - **Production branch:** `main`
+   - **Build command:** `npm run build`
+   - **Build output directory:** `dist`
+   - Framework preset: Astro (or "None" — `wrangler.jsonc` already sets the
+     output dir).
+4. Save & Deploy. You'll get a `https://word2md.pages.dev` URL.
+
+## 2. Verify on the pages.dev URL before touching DNS
+
+- Open `https://word2md.pages.dev/` and a few localized paths (`/id/`, `/vi/`,
+  `/de/`). Confirm pages render and the language switcher works.
+- Test the edge redirect (it only runs on Cloudflare, not locally):
+  ```sh
+  # Should 302 to /de/ (no cookie, German preferred):
+  curl -sI -H 'Accept-Language: de-DE,de;q=0.9' https://word2md.pages.dev/ | grep -i location
+  # Should NOT redirect (English preferred):
+  curl -sI -H 'Accept-Language: en-US,en;q=0.9' https://word2md.pages.dev/ | grep -i -E 'HTTP|location'
+  # Should NOT redirect (cookie already set):
+  curl -sI -H 'Accept-Language: de' -H 'Cookie: lang=en' https://word2md.pages.dev/ | grep -i -E 'HTTP|location'
+  ```
+
+## 3. Move the domain
+
+Apex domains (`word2md.com`) need Cloudflare to manage DNS (for CNAME
+flattening). Recommended path:
+
+1. In Cloudflare: **Add a site** → `word2md.com` → it scans existing DNS records.
+2. At your domain registrar, change the **nameservers** to the two Cloudflare
+   gives you. (Propagation: minutes to a few hours.)
+3. Back in the Pages project: **Custom domains → Set up a custom domain** →
+   `word2md.com` (and optionally `www`). Cloudflare adds the records
+   automatically once it manages the zone.
+4. Wait for the custom domain to show **Active** and HTTPS to provision.
+
+> If you'd rather not move nameservers, you can instead use a `CNAME` to
+> `word2md.pages.dev` on a subdomain, but the apex (`word2md.com`) really wants
+> Cloudflare-managed DNS. Moving nameservers is the clean option.
+
+## 4. Decommission GitHub Pages (after Cloudflare is live)
+
+Once `https://word2md.com` is served by Cloudflare and verified:
+
+1. Repo **Settings → Pages** → set Source to **None** (disables GitHub Pages).
+2. Delete `.github/workflows/static.yml` in a follow-up PR (it deploys to GitHub
+   Pages and is now redundant). Cloudflare's Git integration handles deploys.
+
+## Rollback
+
+If anything looks wrong after the DNS move, revert the nameservers (or the
+custom-domain record) back to GitHub Pages. Because GitHub Pages stays enabled
+until step 4, the old deployment is still there as a fallback.
+
+## Notes & options
+
+- **Build command:** `npm run build` runs the library `tsc` step too; `npm run
+build:site` alone also produces `dist` if you prefer a leaner Pages build.
+- **No auto-redirect, if you prefer:** the language switcher already gives full
+  manual control. If you'd rather not auto-redirect at all (the most
+  conservative SEO choice), delete `functions/index.js` and the inline cookie
+  script in `web/layouts/Layout.astro`; everything else still works.
+- **Tuning the redirect:** supported locales live in `SUPPORTED_LOCALES` in
+  `functions/index.js`; keep it in sync with `web/i18n/index.ts`.

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,72 @@
+// Cloudflare Pages Function for the site root ("/").
+//
+// Runs ONLY on "/" (the file path `functions/index.js` maps to that route), so
+// it never touches localized pages, assets, or the legal pages. On a first
+// visit with no language cookie, it sends the visitor to the best-matching
+// localized home based on their Accept-Language header; otherwise it serves the
+// English root unchanged.
+//
+// This file is inert on GitHub Pages (Functions only run on Cloudflare Pages),
+// so it can live in the repo before the migration is activated.
+//
+// SEO notes: the redirect is a 302 (temporary), every locale is independently
+// crawlable and listed in the sitemap with self-referential hreflang, and the
+// decision is based solely on Accept-Language (no user-agent cloaking). A
+// `lang` cookie — set on every page by a tiny inline script (see Layout.astro)
+// — disables the auto-redirect after the first visit so the language switcher
+// stays in control and there is never a redirect loop.
+
+// Non-default locales we can redirect to. English is the default and lives at
+// the root, so it is intentionally absent (a match for English means "stay").
+// Keep in sync with `locales` in web/i18n/index.ts.
+export const SUPPORTED_LOCALES = ['id', 'vi', 'pt', 'es', 'de', 'fr'];
+
+// Pick the highest-priority supported locale from an Accept-Language header.
+// Returns a locale string, or null to stay on the English default (either
+// because English ranks highest or nothing matched).
+export function pickLocale(acceptLanguage) {
+  if (!acceptLanguage) return null;
+  const ranked = acceptLanguage
+    .split(',')
+    .map((part) => {
+      const [tag, ...params] = part.trim().split(';');
+      const qParam = params.find((p) => p.trim().startsWith('q='));
+      const q = qParam ? parseFloat(qParam.split('=')[1]) : 1;
+      return {
+        base: tag.trim().toLowerCase().split('-')[0],
+        q: Number.isNaN(q) ? 0 : q,
+      };
+    })
+    .filter((entry) => entry.base && entry.base !== '*')
+    .sort((a, b) => b.q - a.q);
+
+  for (const { base } of ranked) {
+    if (base === 'en') return null; // English preferred → stay on the root.
+    if (SUPPORTED_LOCALES.includes(base)) return base;
+  }
+  return null;
+}
+
+export async function onRequest(context) {
+  const { request, next } = context;
+
+  // Respect an existing choice — don't auto-redirect once a language is known.
+  const cookie = request.headers.get('Cookie') || '';
+  if (/(?:^|;\s*)lang=/.test(cookie)) return next();
+
+  const locale = pickLocale(request.headers.get('Accept-Language'));
+  if (!locale) return next();
+
+  const url = new URL(request.url);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      // Preserve any query string (e.g. ?utm_source=…) across the redirect.
+      Location: `${url.origin}/${locale}/${url.search}`,
+      // Set the cookie now so the redirect happens at most once.
+      'Set-Cookie': `lang=${locale}; Path=/; Max-Age=31536000; SameSite=Lax`,
+      'Cache-Control': 'no-store',
+      Vary: 'Accept-Language, Cookie',
+    },
+  });
+}

--- a/src/__tests__/i18n-redirect.test.ts
+++ b/src/__tests__/i18n-redirect.test.ts
@@ -1,0 +1,46 @@
+import { pickLocale, SUPPORTED_LOCALES } from '../../functions/index.js';
+
+// Unit tests for the Accept-Language matching used by the Cloudflare Pages
+// edge redirect (functions/index.js). The Function itself runs on the CF
+// runtime, but the locale-selection logic is pure and worth pinning down.
+
+describe('pickLocale', () => {
+  it('returns null when English ranks highest (stay on the root)', () => {
+    expect(pickLocale('en-US,en;q=0.9')).toBeNull();
+    expect(pickLocale('en')).toBeNull();
+  });
+
+  it('matches a supported language by its base tag', () => {
+    expect(pickLocale('de-DE,de;q=0.9,en;q=0.8')).toBe('de');
+    expect(pickLocale('fr')).toBe('fr');
+    expect(pickLocale('vi-VN')).toBe('vi');
+  });
+
+  it('maps regional Portuguese variants to pt', () => {
+    expect(pickLocale('pt-BR,pt;q=0.9')).toBe('pt');
+    expect(pickLocale('pt-PT')).toBe('pt');
+  });
+
+  it('honors q-value priority over list order', () => {
+    expect(pickLocale('en;q=0.5,de;q=0.9')).toBe('de');
+    expect(pickLocale('de;q=0.3,en;q=0.9')).toBeNull();
+  });
+
+  it('skips unsupported languages', () => {
+    expect(pickLocale('ja,ko;q=0.9')).toBeNull();
+    expect(pickLocale('zh-CN,zh;q=0.9')).toBeNull();
+    expect(pickLocale('ja,es;q=0.8')).toBe('es');
+  });
+
+  it('handles empty / missing / wildcard input', () => {
+    expect(pickLocale('')).toBeNull();
+    expect(pickLocale(null)).toBeNull();
+    expect(pickLocale(undefined)).toBeNull();
+    expect(pickLocale('*')).toBeNull();
+  });
+
+  it('only lists non-default locales (English stays at the root)', () => {
+    expect(SUPPORTED_LOCALES).not.toContain('en');
+    expect(SUPPORTED_LOCALES).toEqual(['id', 'vi', 'pt', 'es', 'de', 'fr']);
+  });
+});

--- a/web/layouts/Layout.astro
+++ b/web/layouts/Layout.astro
@@ -231,5 +231,19 @@ const footerLinks = [
         {t.footerTagline}
       </p>
     </footer>
+    <script is:inline>
+      // Record the current language so the edge redirect (Cloudflare Pages,
+      // functions/index.js) won't auto-redirect on future visits — the language
+      // switcher stays in control. Harmless on GitHub Pages: it sets a cookie
+      // that nothing reads there.
+      try {
+        document.cookie =
+          'lang=' +
+          document.documentElement.lang +
+          '; path=/; max-age=31536000; samesite=lax';
+      } catch (e) {
+        /* cookies unavailable — fine, redirect simply re-evaluates next visit */
+      }
+    </script>
   </body>
 </html>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  // Cloudflare Pages project config. `pages_build_output_dir` points at Astro's
+  // static output; the `functions/` directory at the repo root is picked up
+  // automatically for edge Functions (see functions/index.js). The build
+  // command (`npm run build`) is set in the Pages dashboard / Git integration.
+  "name": "word2md",
+  "compatibility_date": "2026-06-01",
+  "pages_build_output_dir": "dist",
+}


### PR DESCRIPTION
**PR 3 of 3** in the i18n plan. Prepares the repo to move from GitHub Pages to **Cloudflare Pages**, with an edge `Accept-Language` redirect. The site stays a static Astro build (no SSR adapter); the only edge logic is a Pages Function on `/`.

**Everything here is safe to merge before the migration is activated:** GitHub Pages uploads only `./dist`, and Pages Functions only run on Cloudflare — so `functions/` and `wrangler.jsonc` are invisible to the current deploy. The inline cookie script runs on GitHub Pages but is harmless (nothing reads the cookie there).

## What's included
- **`functions/index.js`** — Pages Function scoped to `/`. On a first visit with no `lang` cookie it 302-redirects to the best `Accept-Language` match among the non-default locales (preserving the query string) and sets a `lang` cookie so it fires **at most once**; otherwise serves the English root. Localized paths, assets, and legal pages are never touched.
- **`web/layouts/Layout.astro`** — tiny inline script records the current language in a `lang` cookie, so the switcher stays in control and there's no redirect loop.
- **`wrangler.jsonc`** — Pages config (`pages_build_output_dir: dist`).
- **`docs/cloudflare-migration.md`** — your step-by-step dashboard + DNS walkthrough, ordered so the live site never breaks (verify on `*.pages.dev` → move DNS → disable GitHub Pages), with rollback and a "no auto-redirect" opt-out.

## SEO posture (the safe variant)
302 (temporary); every locale is independently crawlable and in the sitemap with self-referential hreflang; the decision uses **only** `Accept-Language` (no user-agent cloaking), so Googlebot — which sends no/`en` language — indexes English at `/` and reaches localized URLs via hreflang. `/de/` etc. are never intercepted, so search landings aren't bounced.

## Verification
- `pickLocale()` unit-tested (q-values, `pt-BR`→`pt`, unsupported langs, English-stays).
- The **wired Function** integration-tested locally via `wrangler pages dev` (miniflare, no account needed): 302-by-language, no redirect for English / when cookied, localized paths not intercepted, query string preserved, `Set-Cookie` emitted.
- 137 unit + 19 e2e pass, lint clean, full build passes all checks.

## What's NOT in this PR (your steps)
Creating the Cloudflare Pages project, adding the custom domain, and the DNS cutover — all in `docs/cloudflare-migration.md`. `static.yml` (GitHub Pages) is intentionally left in place until cutover; removing it is a follow-up after Cloudflare is verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)