### PR TITLE
Set up Crowdin for crowdsourced translations

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,49 @@
+name: Crowdin
+
+# Syncs translations with Crowdin:
+#  - uploads source strings (web/i18n/en.json) when they change on main, and
+#  - downloads completed translations and opens a PR with them.
+# Requires two repository secrets: CROWDIN_PROJECT_ID and CROWDIN_PERSONAL_TOKEN.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/i18n/en.json'
+      - 'crowdin.yml'
+  schedule:
+    # Weekly, Monday 06:00 UTC — pull in any translations completed that week.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Avoid overlapping sync runs racing on the localization branch.
+concurrency:
+  group: crowdin
+  cancel-in-progress: false
+
+jobs:
+  synchronize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Crowdin upload sources / download translations
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: true
+          # Open a PR with the downloaded translations rather than pushing to main.
+          localization_branch_name: l10n_crowdin
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'Translations synced from Crowdin. Run `npm run fix` if formatting differs, and confirm `npm test` (i18n completeness) passes before merging.'
+          pull_request_base_branch_name: main
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,21 @@
+# Crowdin configuration.
+#
+# Source strings live in web/i18n/en.json. Crowdin writes each translation back
+# as web/i18n/<code>.json, matching our locale filenames (id, vi, pt, es, de,
+# fr). English is the source language and is never overwritten.
+#
+# Credentials come from environment variables (GitHub Actions secrets) — never
+# commit a token here. See .github/workflows/crowdin.yml and web/i18n/README.md.
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+
+preserve_hierarchy: true
+
+files:
+  - source: /web/i18n/en.json
+    translation: /web/i18n/%two_letters_code%.json
+    # Brazilian Portuguese (Crowdin id "pt-BR") writes to pt.json to match our
+    # locale key. The other languages already use their two-letter code.
+    languages_mapping:
+      two_letters_code:
+        pt-BR: pt

--- a/web/i18n/README.md
+++ b/web/i18n/README.md
@@ -34,3 +34,21 @@ wire up crowdsourced translation without further restructuring.
 Non-English locales are a **machine-translated first pass and need native
 review** before they can be considered final. `en` is authored. Legal pages
 (Terms/Privacy) are intentionally English-only.
+
+## Crowdin (crowdsourced translation)
+
+Native review and community translations are managed in Crowdin, configured by
+`crowdin.yml` (repo root) and synced by `.github/workflows/crowdin.yml`:
+
+- The workflow **uploads `en.json`** to Crowdin when it changes on `main`, and
+  on a weekly schedule **downloads completed translations** and opens a
+  `New Crowdin translations` PR.
+- Translations land back in `web/i18n/<code>.json` (Brazilian Portuguese →
+  `pt.json`).
+- Requires two repo secrets: `CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN`.
+
+When reviewing a Crowdin PR: run `npm run fix` if its JSON formatting differs
+from Prettier, and confirm `npm test` (the completeness test) passes. In the
+Crowdin project, keep **"Skip untranslated strings" off** so every key is
+exported (untranslated strings fall back to English) — otherwise the
+completeness test will fail on missing keys.


### PR DESCRIPTION
Wires up [Crowdin](https://crowdin.com) so the machine-translated locales (id/vi/pt/es/de/fr) can get **native review and community translations** through Crowdin's web UI — no git required for translators. Points at `web/i18n/*.json` with `en.json` as the source.

## What's included
- **`crowdin.yml`** — maps source `web/i18n/en.json` → `web/i18n/%two_letters_code%.json`, with Brazilian Portuguese mapped to `pt.json` to match our locale filenames. Credentials come from env vars (`project_id_env`/`api_token_env`); **no token in the repo**.
- **`.github/workflows/crowdin.yml`** — `crowdin/github-action@v2`. Uploads `en.json` when it changes on `main`, and weekly (or via `workflow_dispatch`) downloads completed translations and opens a `New Crowdin translations` PR.
- **`web/i18n/README.md`** — documents the flow, required secrets, and the Crowdin setting needed to keep the completeness test green.

## Your setup steps (Crowdin side)
1. **Apply for the free OSS plan:** <https://crowdin.com/page/open-source-project-setup-request> (ISC-licensed, public — qualifies).
2. **Create the project:** source language **English**; add target languages **Indonesian, Vietnamese, Portuguese (Brazilian), Spanish, German, French**.
3. In **Settings → Files / Export**, keep **"Skip untranslated strings" OFF** (so every key is always exported — required for the completeness test).
4. Grab **Project ID** (project → Settings → API) and a **Personal Access Token** (account → API → New token, with Project scope).
5. Add both as **GitHub repo secrets**: `CROWDIN_PROJECT_ID`, `CROWDIN_PERSONAL_TOKEN` (Settings → Secrets and variables → Actions).
6. Merge this PR, then run the **Crowdin** workflow once (Actions tab → Run workflow) to push `en.json` up.

When a translations PR comes back: run `npm run fix` if its JSON formatting differs, and confirm `npm test` passes before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)