### PR TITLE
Switch book promo CTA to "Buy now" for launch

### DIFF
--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -103,7 +103,7 @@
   "promo": {
     "label": "Vom Macher",
     "body": "Ich habe dieses kostenlose Tool entwickelt — und ich habe das Buch über offenes Arbeiten geschrieben. <strong>Open &amp; Async</strong> ist das auf GitHub erprobte Handbuch für remote und verteilte Teams.",
-    "cta": "Benachrichtigt werden",
+    "cta": "Jetzt kaufen",
     "coverAlt": "Buchcover von Open and Async",
     "resultsLead": "Stark — ein weiteres Dokument raus aus Word und offen zugänglich. Ich habe das Handbuch für diese Arbeitsweise geschrieben:",
     "resultsCta": "Open & Async ansehen"

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -103,7 +103,7 @@
   "promo": {
     "label": "From the maker",
     "body": "I built this free tool — and I wrote the book on working in the open. <strong>Open &amp; Async</strong> is the GitHub-tested playbook for remote and distributed teams.",
-    "cta": "Get notified",
+    "cta": "Buy now",
     "coverAlt": "Open and Async book cover",
     "resultsLead": "Nice — one more doc out of Word and into the open. I wrote the playbook for working this way:",
     "resultsCta": "See Open & Async"

--- a/web/i18n/es.json
+++ b/web/i18n/es.json
@@ -103,7 +103,7 @@
   "promo": {
     "label": "De quien lo creó",
     "body": "Creé esta herramienta gratuita — y escribí el libro sobre trabajar en abierto. <strong>Open &amp; Async</strong> es la guía probada en GitHub para equipos remotos y distribuidos.",
-    "cta": "Recibe novedades",
+    "cta": "Cómpralo ya",
     "coverAlt": "Portada del libro Open and Async",
     "resultsLead": "Genial: un documento más que sale de Word y se vuelve abierto. Escribí la guía para trabajar así:",
     "resultsCta": "Descubre Open & Async"

--- a/web/i18n/fr.json
+++ b/web/i18n/fr.json
@@ -103,7 +103,7 @@
   "promo": {
     "label": "Du créateur",
     "body": "J'ai créé cet outil gratuit — et j'ai écrit le livre sur le travail en mode ouvert. <strong>Open &amp; Async</strong> est le guide éprouvé sur GitHub pour les équipes distantes et distribuées.",
-    "cta": "Être prévenu",
+    "cta": "Acheter maintenant",
     "coverAlt": "Couverture du livre Open and Async",
     "resultsLead": "Bravo — un document de plus sorti de Word et rendu ouvert. J'ai écrit le guide pour travailler ainsi :",
     "resultsCta": "Découvrir Open & Async"

--- a/web/i18n/id.json
+++ b/web/i18n/id.json
@@ -103,7 +103,7 @@
   "promo": {
     "label": "Dari pembuatnya",
     "body": "Saya membuat alat gratis ini — dan saya menulis buku tentang bekerja secara terbuka. <strong>Open &amp; Async</strong> adalah panduan teruji-GitHub untuk tim jarak jauh dan terdistribusi.",
-    "cta": "Dapatkan info terbaru",
+    "cta": "Beli sekarang",
     "coverAlt": "Sampul buku Open and Async",
     "resultsLead": "Bagus — satu dokumen lagi keluar dari Word dan menjadi terbuka. Saya menulis panduan untuk cara kerja seperti ini:",
     "resultsCta": "Lihat Open & Async"

--- a/web/i18n/pt.json
+++ b/web/i18n/pt.json
@@ -103,7 +103,7 @@
   "promo": {
     "label": "De quem criou",
     "body": "Eu criei esta ferramenta gratuita — e escrevi o livro sobre trabalhar de forma aberta. <strong>Open &amp; Async</strong> é o guia testado no GitHub para equipes remotas e distribuídas.",
-    "cta": "Seja avisado",
+    "cta": "Compre agora",
     "coverAlt": "Capa do livro Open and Async",
     "resultsLead": "Ótimo — mais um documento que saiu do Word e virou aberto. Escrevi o guia para trabalhar assim:",
     "resultsCta": "Conheça o Open & Async"

--- a/web/i18n/vi.json
+++ b/web/i18n/vi.json
@@ -103,7 +103,7 @@
   "promo": {
     "label": "Từ người tạo ra công cụ",
     "body": "Tôi đã xây dựng công cụ miễn phí này — và tôi đã viết cuốn sách về cách làm việc cởi mở. <strong>Open &amp; Async</strong> là cẩm nang đã được kiểm chứng trên GitHub dành cho các nhóm làm việc từ xa và phân tán.",
-    "cta": "Nhận thông báo",
+    "cta": "Mua ngay",
     "coverAlt": "Bìa sách Open and Async",
     "resultsLead": "Tuyệt — thêm một tài liệu nữa rời khỏi Word và trở nên cởi mở. Tôi đã viết cẩm nang cho cách làm việc này:",
     "resultsCta": "Xem Open & Async"


### PR DESCRIPTION
## Summary

Open & Async goes on sale **Tuesday (2026-07-21)**. Until now the promo card's primary CTA has been a pre-launch waitlist prompt ("Get notified"). This swaps it to a purchase CTA in all seven locales, ready to merge for launch.

| Locale | Before | After |
| --- | --- | --- |
| en | Get notified | Buy now |
| de | Benachrichtigt werden | Jetzt kaufen |
| es | Recibe novedades | Cómpralo ya |
| fr | Être prévenu | Acheter maintenant |
| id | Dapatkan info terbaru | Beli sekarang |
| pt | Seja avisado | Compre agora |
| vi | Nhận thông báo | Mua ngay |

Only the `promo.cta` key changes. The card's link (`open-and-async.com`) and the contextual results-pane pitch (`promo.resultsCta`) are unchanged.

## Notes
- Merge on/after Tuesday so the "Buy now" label lands with availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)