### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "word-to-markdown",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "word-to-markdown",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@joplin/turndown": "^4.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-to-markdown",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Convert Word documents to beautiful Markdown.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Bumps `package.json` (and the lockfile) `0.1.0` → `0.2.0` ahead of the next npm release.

## Why minor, not patch

Since `0.1.0` was published, the only change to a file that ships in the npm package (`build/main.js`, from `src/main.ts`) is #135:

- **Typed errors:** `convert()` and `convertWithWarnings()` now throw `FileNotFoundError` / `FilePermissionError` / `InvalidFileError` / `ConversionError` with friendly messages instead of raw `fs`/JSZip errors. The CLI's existing `catch` branches now actually surface these.
- **New input validation:** `convert()` now runs path-traversal validation, rejecting `..` and system-directory inputs that previously passed.

That's new behavior (a feature) and potentially breaking for consumers catching the old raw errors or relying on `..` paths — which lands it in the minor slot rather than a patch.

Everything else merged since 0.1.0 (workflow removals, build/lint fixes, dependabot bumps, doc deletion) is not in the published tarball, so it's not user-facing for the package.

## Release

After this merges, cutting a GitHub Release tagged `v0.2.0` will publish it (the workflow's tag↔version guard will match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)