### PR TITLE
Add extract-to-files image support (images: 'extract')

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,20 @@ npx word-to-markdown input.docx > output.md
 - Tables
 - Links
 - Footnotes and endnotes
-- Images — embedded inline as base64 data URIs
+- Images — embedded inline as base64 data URIs, or extracted to files
 
 ### Notes and limitations
 
 - **Numbered lists** are kept as `1./2./3.` ordered lists. Pass
   `{ numberedLists: 'bullets' }` (library) or `--bullet-lists` (CLI) to convert
   them to bullet lists instead (matching the original word-to-markdown).
-- **Images** are inlined as base64 data URIs rather than extracted to separate
-  files. To change this, pass a custom [Mammoth image handler](https://github.com/mwilliamson/mammoth.js/#images)
-  via `options.mammoth` (see [Use as a library](#use-as-a-library)), or drop
-  images entirely with `{ images: 'strip' }` / `--strip-images`.
+- **Images** are inlined as base64 data URIs by default. To extract them to
+  files with relative links instead, use `{ images: 'extract' }` (library — the
+  bytes come back on `ConvertResult.images`) or `--image-dir <dir>` (CLI). Drop
+  them entirely with `{ images: 'strip' }` / `--strip-images`. On the web,
+  documents with images offer a **Download .zip** (Markdown + an `images/`
+  folder). For full control, pass a custom [Mammoth image handler](https://github.com/mwilliamson/mammoth.js/#images)
+  via `options.mammoth`.
 - **Underline** is dropped by default (Mammoth's default, since underlines are
   easily confused with links). Pass `{ underline: 'preserve' }` (library) or
   `--underline` (CLI) to keep it as an inline `<u>` tag.
@@ -81,6 +84,9 @@ Options:
 - `--bullet-lists` — convert numbered lists to bullets instead of keeping `1./2./3.`.
 - `--underline` — preserve underlined text as inline `<u>` tags (dropped by default).
 - `--strip-images` — remove images instead of embedding them as base64 data URIs.
+- `--image-dir <dir>` — extract images to `<dir>` and link them relatively, instead
+  of embedding base64. Links resolve relative to where you save the Markdown, e.g.
+  `w2m --image-dir images report.docx > report.md`.
 
 ## Use as a library
 
@@ -111,20 +117,22 @@ const { markdown } = await convertWithWarnings(arrayBuffer);
 ### API
 
 - **`convert(input, options?): Promise<string>`** — resolves to the Markdown.
-- **`convertWithWarnings(input, options?): Promise<{ markdown: string; warnings: string[] }>`** — also returns human-readable warnings for encrypted, protected, or sensitivity-labeled documents.
+- **`convertWithWarnings(input, options?): Promise<{ markdown: string; warnings: string[]; images? }>`** — also returns human-readable warnings for encrypted, protected, or sensitivity-labeled documents, and (in `extract` mode) the extracted images.
 
 `input` is a file-path `string` (Node) or an `ArrayBuffer` (browser). `options` is optional:
 
-- **`images`** — `'inline'` (default) embeds images as base64 data URIs; `'strip'` removes them.
+- **`images`** — `'inline'` (default) embeds images as base64 data URIs; `'strip'` removes them; `'extract'` replaces each with a relative `![](imageDir/imageN.ext)` link and returns the bytes on `ConvertResult.images` (use `convertWithWarnings` to retrieve them).
+- **`imageDir`** — link/path prefix for extracted images (default `'images'`); only applies with `images: 'extract'`.
 - **`numberedLists`** — `'ordered'` (default) keeps `1./2./3.`; `'bullets'` converts numbered lists to bullets.
 - **`underline`** — `'ignore'` (default) drops underlines; `'preserve'` keeps them as inline `<u>` tags.
 - **`mammoth`** / **`turndown`** — escape hatches forwarded to [Mammoth](https://github.com/mwilliamson/mammoth.js/) and [Turndown](https://github.com/mixmark-io/turndown) respectively.
 
 ```js
-const markdown = await convert('file.docx', {
-  numberedLists: 'bullets',
-  underline: 'preserve',
+// Extract images to files and write them out yourself:
+const { markdown, images } = await convertWithWarnings('file.docx', {
+  images: 'extract',
 });
+// markdown → ![](images/image1.png); images → [{ path, contentType, bytes }]
 ```
 
 ### Error handling

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync, statSync } from 'fs';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -92,6 +93,24 @@ describe('w2m CLI', () => {
     expect(stripped.status).toBe(0);
     expect(stripped.stdout).not.toContain('data:image');
     expect(stripped.stdout).toContain('Text after image.');
+  });
+
+  it('--image-dir extracts images to files and links them relatively', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'w2m-images-'));
+    try {
+      const result = runCli(['--image-dir', dir, fixture('image.docx')]);
+      expect(result.status).toBe(0);
+      // No base64 in the Markdown; a relative link to the written file instead.
+      // (runCli only captures stderr on a non-zero exit, so the "Wrote N image"
+      // notice isn't asserted here — the written file below is the real proof.)
+      expect(result.stdout).not.toContain('data:image');
+      expect(result.stdout).toContain(`${dir}/image1.png`);
+      // The file exists on disk with real bytes.
+      expect(existsSync(path.join(dir, 'image1.png'))).toBe(true);
+      expect(statSync(path.join(dir, 'image1.png')).size).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('keeps numbered lists numbered by default', () => {

--- a/src/__tests__/image-extract.test.ts
+++ b/src/__tests__/image-extract.test.ts
@@ -1,0 +1,64 @@
+import convert, {
+  convertWithWarnings,
+  extensionForContentType,
+} from '../main.js';
+
+const IMAGE = 'src/__fixtures__/image.docx';
+
+// End-to-end coverage for `images: 'extract'`, which replaces Mammoth's default
+// base64 inlining with relative links plus the raw bytes on ConvertResult.images.
+describe("images: 'extract' (end to end)", () => {
+  it('links images relatively and returns their bytes', async () => {
+    const result = await convertWithWarnings(IMAGE, { images: 'extract' });
+    expect(result.markdown).toContain('![](images/image1.png)');
+    expect(result.markdown).not.toContain('data:image');
+    expect(result.images).toHaveLength(1);
+    const [image] = result.images!;
+    expect(image).toMatchObject({
+      path: 'images/image1.png',
+      contentType: 'image/png',
+    });
+    expect(image.bytes).toBeInstanceOf(Uint8Array);
+    expect(image.bytes.length).toBeGreaterThan(0);
+  });
+
+  it('honors a custom imageDir for both the link and the returned path', async () => {
+    const result = await convertWithWarnings(IMAGE, {
+      images: 'extract',
+      imageDir: 'assets',
+    });
+    expect(result.markdown).toContain('![](assets/image1.png)');
+    expect(result.images![0].path).toBe('assets/image1.png');
+  });
+
+  it('leaves images inline (base64) by default and omits the images field', async () => {
+    const result = await convertWithWarnings(IMAGE);
+    expect(result.markdown).toContain('data:image/png;base64');
+    expect(result.images).toBeUndefined();
+  });
+
+  it('the default-export convert() still returns the linked Markdown string', async () => {
+    const md = await convert(IMAGE, { images: 'extract' });
+    expect(md).toContain('![](images/image1.png)');
+  });
+});
+
+describe('extensionForContentType', () => {
+  it.each([
+    ['image/png', 'png'],
+    ['image/jpeg', 'jpg'],
+    ['image/jpg', 'jpg'],
+    ['image/gif', 'gif'],
+    ['image/tiff', 'tiff'],
+    ['image/bmp', 'bmp'],
+    ['image/webp', 'webp'],
+    ['image/svg+xml', 'svg'],
+    ['image/x-emf', 'emf'],
+    ['image/x-wmf', 'wmf'],
+    ['IMAGE/PNG', 'png'], // case-insensitive
+    ['image/avif', 'avif'], // unknown but clean subtype → subtype
+    ['image/x-weird', 'bin'], // non-alphanumeric subtype → bin
+  ])('maps %s → %s', (contentType, expected) => {
+    expect(extensionForContentType(contentType)).toBe(expected);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { mkdir, writeFile } from 'fs/promises';
 import {
   convertWithWarnings,
   UnsupportedFileError,
@@ -21,6 +22,11 @@ program
     'Remove images instead of embedding them as base64 data URIs',
   )
   .option(
+    '--image-dir <dir>',
+    'Extract images to <dir> and link them relatively, instead of embedding ' +
+      'them as base64. Links resolve relative to where you save the Markdown.',
+  )
+  .option(
     '--bullet-lists',
     'Convert numbered lists to bullets rather than keeping them as 1./2./3.',
   )
@@ -30,11 +36,30 @@ program
   )
   .action(async (file, options) => {
     try {
+      // --image-dir (extract) takes precedence over --strip-images.
+      const images = options.imageDir
+        ? 'extract'
+        : options.stripImages
+          ? 'strip'
+          : 'inline';
       const result = await convertWithWarnings(file, {
-        images: options.stripImages ? 'strip' : 'inline',
+        images,
+        imageDir: options.imageDir,
         numberedLists: options.bulletLists ? 'bullets' : 'ordered',
         underline: options.underline ? 'preserve' : 'ignore',
       });
+
+      // Write extracted images to disk before emitting the Markdown that links
+      // them. Paths are already prefixed with the requested directory.
+      if (result.images && result.images.length > 0) {
+        await mkdir(options.imageDir, { recursive: true });
+        await Promise.all(
+          result.images.map((image) => writeFile(image.path, image.bytes)),
+        );
+        console.error(
+          `Wrote ${result.images.length} image(s) to ${options.imageDir}/`,
+        );
+      }
 
       // Display warnings to stderr if any
       if (result.warnings.length > 0) {

--- a/src/converter.worker.ts
+++ b/src/converter.worker.ts
@@ -9,6 +9,9 @@ import { convertWithWarnings } from './main.js';
 interface ConvertRequest {
   id: number;
   buffer: ArrayBuffer;
+  // When true, extract images to relative files (returned on result.images)
+  // instead of inlining them as base64. Used by the "Download .zip" action.
+  extract?: boolean;
 }
 
 const ctx = self as unknown as DedicatedWorkerGlobalScope;
@@ -19,9 +22,12 @@ const ctx = self as unknown as DedicatedWorkerGlobalScope;
 ctx.postMessage({ type: 'ready' });
 
 ctx.onmessage = async (event: MessageEvent<ConvertRequest>): Promise<void> => {
-  const { id, buffer } = event.data;
+  const { id, buffer, extract } = event.data;
   try {
-    const result = await convertWithWarnings(buffer);
+    const result = await convertWithWarnings(
+      buffer,
+      extract ? { images: 'extract' } : undefined,
+    );
     ctx.postMessage({ id, ok: true, result });
   } catch (error) {
     // Errors can't cross the worker boundary as class instances, so forward the

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import ClipboardJS from 'clipboard';
+import type { ExtractedImage } from './main.js';
 
 // Upper bound on the file we'll attempt to read into memory and convert
 // client-side. Comfortably above any real Word document; guards against a
@@ -9,6 +10,13 @@ const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
 // "Downloaded" confirmation (mirrors the copy button). Initialized on load.
 let downloadLabelDefault = '';
 let downloadResetTimer: number | undefined;
+// Same, for the "Download .zip" button (shown only when a doc has images).
+let downloadZipLabelDefault = '';
+let downloadZipResetTimer: number | undefined;
+// The most recently converted document's bytes, retained so "Download .zip" can
+// re-run the conversion in extract mode (the on-screen Markdown inlines images
+// as base64; the zip needs them as separate files).
+let lastConvertedBuffer: ArrayBuffer | null = null;
 
 // The Word→Markdown converter and the Markdown→HTML renderer pull in heavy
 // dependencies (mammoth, turndown, jszip, unified/remark/rehype, prettier,
@@ -72,6 +80,7 @@ async function renderPreview(
 interface ConversionResult {
   markdown: string;
   warnings: string[];
+  images?: ExtractedImage[];
 }
 
 // How long to wait for the worker to signal it has loaded before giving up and
@@ -143,14 +152,17 @@ function getConverterWorker(): Worker {
   return worker;
 }
 
-function convertViaWorker(buffer: ArrayBuffer): Promise<ConversionResult> {
+function convertViaWorker(
+  buffer: ArrayBuffer,
+  extract = false,
+): Promise<ConversionResult> {
   const worker = getConverterWorker();
   const id = ++workerMessageId;
   return new Promise<ConversionResult>((resolve, reject) => {
     pendingConversions.set(id, { resolve, reject });
     // Structured-clone (don't transfer) the buffer so it stays valid for a
     // main-thread fallback if the worker turns out to be unavailable.
-    worker.postMessage({ id, buffer });
+    worker.postMessage({ id, buffer, extract });
   });
 }
 
@@ -158,18 +170,24 @@ function convertViaWorker(buffer: ArrayBuffer): Promise<ConversionResult> {
 // transparent main-thread fallback (older browsers, or a worker that never
 // loads or hangs). A genuine conversion error propagates; only infrastructure
 // failures fall back.
-async function convertBuffer(buffer: ArrayBuffer): Promise<ConversionResult> {
+async function convertBuffer(
+  buffer: ArrayBuffer,
+  extract = false,
+): Promise<ConversionResult> {
   if (typeof Worker !== 'undefined' && !workerUnavailable) {
     try {
       getConverterWorker();
       await workerReady; // rejects (WorkerInfraError) on load timeout/failure
-      return await convertViaWorker(buffer);
+      return await convertViaWorker(buffer, extract);
     } catch (error) {
       if (!(error instanceof WorkerInfraError)) throw error;
     }
   }
   const { convertWithWarnings } = await import('./main.js');
-  return convertWithWarnings(buffer);
+  return convertWithWarnings(
+    buffer,
+    extract ? { images: 'extract' } : undefined,
+  );
 }
 
 // True for legacy .doc files. Checked on the main thread because the worker
@@ -325,6 +343,16 @@ async function processFile(file: File | undefined): Promise<void> {
       const filenameElement = document.getElementById('filename');
       filenameElement.innerText = file.name;
 
+      // Retain the source bytes and offer "Download .zip" only when the document
+      // actually has images (inline mode embeds them as base64 data URIs).
+      lastConvertedBuffer = reader.result as ArrayBuffer;
+      const zipButton = document.getElementById('download-zip-button');
+      if (zipButton) {
+        zipButton.style.display = result.markdown.includes('data:image')
+          ? 'inline-flex'
+          : 'none';
+      }
+
       const inputElement = document.getElementById('input');
       inputElement.classList.add('hidden');
 
@@ -377,6 +405,7 @@ function uiString(
     | 'dismiss'
     | 'copied'
     | 'downloaded'
+    | 'downloadedZip'
     | 'fileTooLarge'
     | 'conversionAnnouncement'
     | 'converting',
@@ -502,6 +531,11 @@ function resetConverter(): void {
   const fileInput = document.getElementById('file') as HTMLInputElement | null;
   if (fileInput) fileInput.value = '';
 
+  // Drop the retained bytes and re-hide the zip button for the next document.
+  lastConvertedBuffer = null;
+  const zipButton = document.getElementById('download-zip-button');
+  if (zipButton) zipButton.style.display = 'none';
+
   document.getElementById('error-alert')?.remove();
   document.getElementById('warning-alert')?.remove();
 
@@ -545,6 +579,56 @@ function downloadMarkdown(): void {
     downloadResetTimer = window.setTimeout(() => {
       label.textContent = downloadLabelDefault;
     }, 2000);
+  }
+}
+
+// Download a .zip containing the Markdown (with relative image links) plus an
+// images/ folder. Re-runs the conversion in extract mode against the retained
+// source bytes, then bundles the result with JSZip (already a dependency).
+async function downloadZip(): Promise<void> {
+  if (!lastConvertedBuffer) return;
+  const button = document.getElementById(
+    'download-zip-button',
+  ) as HTMLButtonElement | null;
+  const label = document.getElementById('download-zip-label');
+  const sourceName =
+    document.getElementById('filename')?.innerText ?? 'document';
+  const baseName = sourceName.replace(/\.docx$/i, '') || 'document';
+
+  if (button) button.disabled = true;
+  try {
+    const [{ default: JSZip }, result] = await Promise.all([
+      import('jszip'),
+      convertBuffer(lastConvertedBuffer, true),
+    ]);
+
+    const zip = new JSZip();
+    zip.file(`${baseName}.md`, result.markdown);
+    for (const image of result.images ?? []) {
+      zip.file(image.path, image.bytes);
+    }
+    const blob = await zip.generateAsync({ type: 'blob' });
+
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `${baseName}.zip`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+
+    if (label) {
+      label.textContent = uiString('downloadedZip', 'Downloaded');
+      window.clearTimeout(downloadZipResetTimer);
+      downloadZipResetTimer = window.setTimeout(() => {
+        label.textContent = downloadZipLabelDefault;
+      }, 2000);
+    }
+  } catch (error) {
+    showConversionError(error);
+  } finally {
+    if (button) button.disabled = false;
   }
 }
 
@@ -613,6 +697,13 @@ document.addEventListener('DOMContentLoaded', () => {
     downloadLabelDefault =
       document.getElementById('download-label')?.textContent ?? '';
     downloadButton.addEventListener('click', downloadMarkdown);
+  }
+
+  const downloadZipButton = document.getElementById('download-zip-button');
+  if (downloadZipButton !== null) {
+    downloadZipLabelDefault =
+      document.getElementById('download-zip-label')?.textContent ?? '';
+    downloadZipButton.addEventListener('click', () => void downloadZip());
   }
 
   const convertAnotherButton = document.getElementById('convert-another');

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,9 +16,18 @@ interface convertOptions {
   /**
    * How to handle images. `'inline'` (default) keeps Mammoth's base64 data
    * URIs; `'strip'` removes images entirely (useful to avoid multi-MB output
-   * from image-heavy documents).
+   * from image-heavy documents); `'extract'` replaces each image with a
+   * relative `![](imageDir/imageN.ext)` link and returns the image bytes on
+   * `ConvertResult.images` (use `convertWithWarnings` to retrieve them).
    */
-  images?: 'inline' | 'strip';
+  images?: 'inline' | 'strip' | 'extract';
+  /**
+   * Directory prefix used for extracted image links and paths (default
+   * `'images'`). Only applies when `images` is `'extract'`. The same value is
+   * used for the Markdown link (`![](imageDir/imageN.ext)`) and the returned
+   * `ExtractedImage.path`, so links and files always agree.
+   */
+  imageDir?: string;
   /**
    * How to render Word's numbered lists. `'ordered'` (default) keeps them as
    * `1.`/`2.`/… ordered lists; `'bullets'` converts them to bullet lists
@@ -43,9 +52,20 @@ interface MammothOptions {
   [key: string]: unknown;
 }
 
+// An image pulled out of the document by `images: 'extract'`. `path` is the
+// relative link used in the Markdown (e.g. `images/image1.png`); `bytes` is the
+// raw file content for the caller to write to disk or bundle into a zip.
+export interface ExtractedImage {
+  path: string;
+  contentType: string;
+  bytes: Uint8Array;
+}
+
 export interface ConvertResult {
   markdown: string;
   warnings: string[];
+  /** Present (possibly empty) when converting with `images: 'extract'`. */
+  images?: ExtractedImage[];
 }
 
 interface DocumentProperties {
@@ -590,19 +610,94 @@ function withUnderlineStyleMap(
   return { ...mammothOptions, styleMap: [...existing, 'u => u'] };
 }
 
+// Common image content types → file extension. Word most often embeds PNG and
+// JPEG; the rest cover formats Mammoth may surface. EMF/WMF are extracted as
+// bytes for completeness but browsers can't render them (Mammoth won't transcode).
+const CONTENT_TYPE_EXTENSIONS: { [contentType: string]: string } = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/gif': 'gif',
+  'image/tiff': 'tiff',
+  'image/bmp': 'bmp',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'image/x-emf': 'emf',
+  'image/x-wmf': 'wmf',
+};
+
+// Pick a file extension for an extracted image. Falls back to the content
+// type's subtype when it's a clean alphanumeric token, else `bin`. Exported for
+// unit testing since only a PNG fixture exists.
+export function extensionForContentType(contentType: string): string {
+  const normalized = contentType.toLowerCase();
+  const known = CONTENT_TYPE_EXTENSIONS[normalized];
+  if (known) return known;
+  const subtype = normalized.split('/')[1] ?? '';
+  return /^[a-z0-9]+$/.test(subtype) ? subtype : 'bin';
+}
+
+// Decode a base64 string to bytes in both Node (Buffer) and the browser (atob).
+// Mammoth's `image.read('base64')` is the one encoding available in every build.
+function base64ToBytes(b64: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(b64, 'base64'));
+  }
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+// Build a Mammoth `convertImage` handler that pulls each image out into a byte
+// array with a deterministic relative path (`imageDir/imageN.ext`) instead of
+// inlining it as a base64 data URI. The collected images are exposed on the
+// returned `images` array once conversion finishes.
+function createImageExtractor(imageDir: string): {
+  images: ExtractedImage[];
+  convertImage: unknown;
+} {
+  const images: ExtractedImage[] = [];
+  const convertImage = mammoth.images.imgElement(async (image) => {
+    const bytes = base64ToBytes(await image.read('base64'));
+    const ext = extensionForContentType(image.contentType);
+    const path = `${imageDir}/image${images.length + 1}.${ext}`;
+    images.push({ path, contentType: image.contentType, bytes });
+    return { src: path };
+  });
+  return { images, convertImage };
+}
+
 // The shared conversion pipeline: mammoth HTML -> cleaned, formatted Markdown.
-// Returns mammoth's messages so callers can surface content-loss warnings.
+// Returns mammoth's messages so callers can surface content-loss warnings, and
+// (in extract mode) the extracted image assets.
 async function runConversionPipeline(
   mammothInput: MammothInput,
   options: convertOptions,
-): Promise<{ markdown: string; messages: MammothMessage[] }> {
+): Promise<{
+  markdown: string;
+  messages: MammothMessage[];
+  images?: ExtractedImage[];
+}> {
   // Preserving underline requires cooperation at both ends of the pipeline:
   // Mammoth must be told to emit `<u>` (it drops underlines by default), and
   // Turndown must be told to keep that tag rather than flatten it to text.
   const preserveUnderline = options.underline === 'preserve';
-  const mammothOptions = preserveUnderline
+  let mammothOptions: MammothOptions | undefined = preserveUnderline
     ? withUnderlineStyleMap(options.mammoth as MammothOptions | undefined)
-    : options.mammoth;
+    : (options.mammoth as MammothOptions | undefined);
+
+  // Extract mode swaps Mammoth's default base64 inliner for a collector that
+  // returns each image's bytes and rewrites the src to a relative path.
+  let extractor:
+    { images: ExtractedImage[]; convertImage: unknown } | undefined;
+  if (options.images === 'extract') {
+    extractor = createImageExtractor(options.imageDir ?? 'images');
+    mammothOptions = {
+      ...mammothOptions,
+      convertImage: extractor.convertImage,
+    };
+  }
 
   const mammothResult = await mammoth.convertToHtml(
     mammothInput,
@@ -624,7 +719,11 @@ async function runConversionPipeline(
   const normalizedMd = normalizeText(listMd);
   const cleanedMd = lint(normalizedMd);
   const formattedMd = await prettify(cleanedMd);
-  return { markdown: formattedMd, messages: mammothResult.messages };
+  return {
+    markdown: formattedMd,
+    messages: mammothResult.messages,
+    images: extractor?.images,
+  };
 }
 
 // Substrings (lower-cased) that, in a thrown error's message, indicate the
@@ -781,13 +880,13 @@ export async function convertWithWarnings(
     const properties = await extractDocumentProperties(propertiesInput);
     const warnings = generateWarnings(properties);
 
-    const { markdown, messages } = await runConversionPipeline(
+    const { markdown, messages, images } = await runConversionPipeline(
       mammothInput,
       options,
     );
     warnings.push(...extractMammothWarnings(messages));
 
-    return { markdown, warnings };
+    return images ? { markdown, warnings, images } : { markdown, warnings };
   } catch (error) {
     classifyConversionError(error, filePath);
   }

--- a/web/components/home/Converter.astro
+++ b/web/components/home/Converter.astro
@@ -30,6 +30,7 @@ const t = useTranslations(asLocale(Astro.props.lang));
     data-converting={t.convertingStatus}
     data-copied={t.copiedButton}
     data-downloaded={t.downloadedButton}
+    data-downloaded-zip={t.downloadedZipButton}
     data-dismiss={t.dismiss}
   >
     <label
@@ -135,6 +136,33 @@ const t = useTranslations(asLocale(Astro.props.lang));
             <path d="M12 15V3" />
           </svg>
           <span id="download-label">{t.downloadButton}</span>
+        </button>
+        <button
+          id="download-zip-button"
+          type="button"
+          style="display:none"
+          class="inline-flex items-center gap-2 rounded-lg border border-navy/15 bg-paper-card px-3.5 py-2 text-sm font-medium text-navy transition-colors hover:border-chartreuse hover:bg-chartreuse/10 disabled:opacity-60 dark:border-white/15 dark:bg-ink-card dark:text-[#eef0f6] dark:hover:border-chartreuse"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="15"
+            height="15"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path
+              d="M21 8v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"
+            />
+            <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+            <rect x="9" y="12" width="2" height="2" />
+            <rect x="9" y="16" width="2" height="2" />
+          </svg>
+          <span id="download-zip-label">{t.downloadZipButton}</span>
         </button>
         <button
           id="convert-another"

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -14,6 +14,8 @@
   "copiedButton": "Kopiert!",
   "downloadButton": ".md herunterladen",
   "downloadedButton": "Heruntergeladen",
+  "downloadZipButton": ".zip herunterladen",
+  "downloadedZipButton": "Heruntergeladen",
   "convertAnother": "Weitere Datei konvertieren",
   "panelMarkdown": "Markdown",
   "panelPreview": "Vorschau",

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -30,7 +30,7 @@
     },
     {
       "t": "Kopieren oder speichern",
-      "d": "Kopiere das Markdown oder lade eine .md-Datei herunter."
+      "d": "Kopiere das Markdown, lade eine .md-Datei herunter oder ein .zip mit deinen Bildern."
     }
   ],
   "conversionHeading": "Was konvertiert wird",
@@ -101,7 +101,8 @@
     "Word (.docx) in Markdown umwandeln",
     "Google Docs in Markdown umwandeln",
     "Markdown-Ausgabe im GitHub-Stil",
-    "100% clientseitig — nichts wird hochgeladen"
+    "100% clientseitig — nichts wird hochgeladen",
+    "Bilder als Dateien extrahieren"
   ],
   "errorGeneric": "Beim Umwandeln des Dokuments ist ein unerwarteter Fehler aufgetreten. Bitte versuche es erneut.",
   "docFileError": "Dieses Tool liest moderne .docx-Dateien, keine älteren .doc-Dateien. Öffnen Sie Ihr Dokument in Word und wählen Sie Datei → Speichern unter → Word-Dokument (.docx), und ziehen Sie die .docx-Datei dann hierher.",

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -14,6 +14,8 @@
   "copiedButton": "Copied!",
   "downloadButton": "Download .md",
   "downloadedButton": "Downloaded",
+  "downloadZipButton": "Download .zip",
+  "downloadedZipButton": "Downloaded",
   "convertAnother": "Convert another file",
   "panelMarkdown": "Markdown",
   "panelPreview": "Preview",

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -30,7 +30,7 @@
     },
     {
       "t": "Copy or save",
-      "d": "Copy the Markdown, or download a .md file."
+      "d": "Copy the Markdown, download a .md file, or grab a .zip with your images."
     }
   ],
   "conversionHeading": "What gets converted",
@@ -101,7 +101,8 @@
     "Convert Word (.docx) to Markdown",
     "Convert Google Docs to Markdown",
     "GitHub-flavored Markdown output",
-    "100% client-side — nothing is uploaded"
+    "100% client-side — nothing is uploaded",
+    "Extract images to files"
   ],
   "errorGeneric": "An unexpected error occurred while converting the document. Please try again.",
   "docFileError": "This tool reads modern .docx files, not older .doc files. In Word, open your document and choose File → Save As → Word Document (.docx), then drop the .docx here.",

--- a/web/i18n/es.json
+++ b/web/i18n/es.json
@@ -14,6 +14,8 @@
   "copiedButton": "¡Copiado!",
   "downloadButton": "Descargar .md",
   "downloadedButton": "Descargado",
+  "downloadZipButton": "Descargar .zip",
+  "downloadedZipButton": "Descargado",
   "convertAnother": "Convertir otro archivo",
   "panelMarkdown": "Markdown",
   "panelPreview": "Vista previa",

--- a/web/i18n/es.json
+++ b/web/i18n/es.json
@@ -30,7 +30,7 @@
     },
     {
       "t": "Copiar o guardar",
-      "d": "Copia el Markdown o descarga un archivo .md."
+      "d": "Copia el Markdown, descarga un archivo .md o un .zip con tus imágenes."
     }
   ],
   "conversionHeading": "Qué se convierte",
@@ -101,7 +101,8 @@
     "Convertir Word (.docx) a Markdown",
     "Convertir Documentos de Google a Markdown",
     "Salida en Markdown con formato de GitHub",
-    "100% del lado del cliente: no se sube nada"
+    "100% del lado del cliente: no se sube nada",
+    "Extraer imágenes a archivos"
   ],
   "errorGeneric": "Ocurrió un error inesperado al convertir el documento. Inténtalo de nuevo.",
   "docFileError": "Esta herramienta lee archivos .docx modernos, no archivos .doc más antiguos. En Word, abre tu documento y elige Archivo → Guardar como → Documento de Word (.docx), y luego arrastra el .docx aquí.",

--- a/web/i18n/fr.json
+++ b/web/i18n/fr.json
@@ -14,6 +14,8 @@
   "copiedButton": "Copié !",
   "downloadButton": "Télécharger .md",
   "downloadedButton": "Téléchargé",
+  "downloadZipButton": "Télécharger .zip",
+  "downloadedZipButton": "Téléchargé",
   "convertAnother": "Convertir un autre fichier",
   "panelMarkdown": "Markdown",
   "panelPreview": "Aperçu",

--- a/web/i18n/fr.json
+++ b/web/i18n/fr.json
@@ -30,7 +30,7 @@
     },
     {
       "t": "Copier ou enregistrer",
-      "d": "Copiez le Markdown, ou téléchargez un fichier .md."
+      "d": "Copiez le Markdown, téléchargez un fichier .md, ou un .zip avec vos images."
     }
   ],
   "conversionHeading": "Ce qui est converti",
@@ -101,7 +101,8 @@
     "Convertir Word (.docx) en Markdown",
     "Convertir Google Docs en Markdown",
     "Sortie Markdown au format GitHub",
-    "100% côté client — rien n'est envoyé"
+    "100% côté client — rien n'est envoyé",
+    "Extraire les images vers des fichiers"
   ],
   "errorGeneric": "Une erreur inattendue s'est produite lors de la conversion du document. Veuillez réessayer.",
   "docFileError": "Cet outil lit les fichiers .docx modernes, pas les anciens fichiers .doc. Dans Word, ouvrez votre document et choisissez Fichier → Enregistrer sous → Document Word (.docx), puis déposez le .docx ici.",

--- a/web/i18n/id.json
+++ b/web/i18n/id.json
@@ -30,7 +30,7 @@
     },
     {
       "t": "Salin atau simpan",
-      "d": "Salin Markdown, atau unduh file .md."
+      "d": "Salin Markdown, unduh file .md, atau .zip berisi gambar Anda."
     }
   ],
   "conversionHeading": "Apa yang dikonversi",
@@ -101,7 +101,8 @@
     "Konversi Word (.docx) ke Markdown",
     "Konversi Google Docs ke Markdown",
     "Keluaran Markdown bergaya GitHub",
-    "100% di sisi klien — tidak ada yang diunggah"
+    "100% di sisi klien — tidak ada yang diunggah",
+    "Ekstrak gambar ke file"
   ],
   "errorGeneric": "Terjadi kesalahan tak terduga saat mengonversi dokumen. Silakan coba lagi.",
   "docFileError": "Alat ini membaca berkas .docx modern, bukan berkas .doc lama. Di Word, buka dokumen Anda dan pilih Berkas → Simpan Sebagai → Dokumen Word (.docx), lalu seret berkas .docx itu ke sini.",

--- a/web/i18n/id.json
+++ b/web/i18n/id.json
@@ -14,6 +14,8 @@
   "copiedButton": "Tersalin!",
   "downloadButton": "Unduh .md",
   "downloadedButton": "Terunduh",
+  "downloadZipButton": "Unduh .zip",
+  "downloadedZipButton": "Terunduh",
   "convertAnother": "Konversi berkas lain",
   "panelMarkdown": "Markdown",
   "panelPreview": "Pratinjau",

--- a/web/i18n/pt.json
+++ b/web/i18n/pt.json
@@ -14,6 +14,8 @@
   "copiedButton": "Copiado!",
   "downloadButton": "Baixar .md",
   "downloadedButton": "Baixado",
+  "downloadZipButton": "Baixar .zip",
+  "downloadedZipButton": "Baixado",
   "convertAnother": "Converter outro arquivo",
   "panelMarkdown": "Markdown",
   "panelPreview": "Visualização",

--- a/web/i18n/pt.json
+++ b/web/i18n/pt.json
@@ -30,7 +30,7 @@
     },
     {
       "t": "Copiar ou salvar",
-      "d": "Copie o Markdown ou baixe um arquivo .md."
+      "d": "Copie o Markdown, baixe um arquivo .md ou um .zip com suas imagens."
     }
   ],
   "conversionHeading": "O que é convertido",
@@ -101,7 +101,8 @@
     "Converter Word (.docx) em Markdown",
     "Converter Google Docs em Markdown",
     "Saída em Markdown no padrão GitHub",
-    "100% no cliente — nada é enviado"
+    "100% no cliente — nada é enviado",
+    "Extrair imagens para arquivos"
   ],
   "errorGeneric": "Ocorreu um erro inesperado ao converter o documento. Tente novamente.",
   "docFileError": "Esta ferramenta lê arquivos .docx modernos, não arquivos .doc mais antigos. No Word, abra seu documento e escolha Arquivo → Salvar como → Documento do Word (.docx), depois arraste o .docx aqui.",

--- a/web/i18n/types.ts
+++ b/web/i18n/types.ts
@@ -41,6 +41,10 @@ export interface UIStrings {
   downloadButton: string;
   /** Transient confirmation shown on the download button after a download. */
   downloadedButton: string;
+  /** Label for the button that downloads a .zip of the Markdown + extracted images. */
+  downloadZipButton: string;
+  /** Transient confirmation shown on the .zip download button after a download. */
+  downloadedZipButton: string;
   /** Resets the converter to accept another document. */
   convertAnother: string;
   panelMarkdown: string;

--- a/web/i18n/vi.json
+++ b/web/i18n/vi.json
@@ -30,7 +30,7 @@
     },
     {
       "t": "Sao chép hoặc lưu",
-      "d": "Sao chép Markdown, hoặc tải tệp .md."
+      "d": "Sao chép Markdown, tải tệp .md, hoặc tệp .zip kèm hình ảnh của bạn."
     }
   ],
   "conversionHeading": "Những gì được chuyển đổi",
@@ -101,7 +101,8 @@
     "Chuyển Word (.docx) sang Markdown",
     "Chuyển Google Docs sang Markdown",
     "Kết quả Markdown chuẩn GitHub",
-    "100% phía máy khách — không có gì được tải lên"
+    "100% phía máy khách — không có gì được tải lên",
+    "Trích xuất hình ảnh ra tệp"
   ],
   "errorGeneric": "Đã xảy ra lỗi không mong muốn khi chuyển đổi tài liệu. Vui lòng thử lại.",
   "docFileError": "Công cụ này đọc các tệp .docx hiện đại, không phải tệp .doc cũ. Trong Word, hãy mở tài liệu của bạn và chọn Tệp → Lưu dưới dạng → Tài liệu Word (.docx), rồi kéo tệp .docx đó vào đây.",

--- a/web/i18n/vi.json
+++ b/web/i18n/vi.json
@@ -14,6 +14,8 @@
   "copiedButton": "Đã sao chép!",
   "downloadButton": "Tải .md",
   "downloadedButton": "Đã tải xuống",
+  "downloadZipButton": "Tải .zip",
+  "downloadedZipButton": "Đã tải xuống",
   "convertAnother": "Chuyển đổi tệp khác",
   "panelMarkdown": "Markdown",
   "panelPreview": "Xem trước",


### PR DESCRIPTION
## Summary

Images were all-or-nothing: bloated **inline base64** (the default) or **discarded** (`strip`). This adds a third mode, **`extract`**, that pulls images out to files with relative links — the middle ground the original Ruby word-to-markdown had.

A single collection **core** returns the assets in the result; each surface drains them into its own sink. (The web worker `postMessage`s results back and functions can't cross that boundary, so extraction collects internally and returns bytes rather than taking a caller callback.)

## What's new

- **Library** — `images: 'extract'` swaps Mammoth's base64 inliner for a collector (`mammoth.images.imgElement`) that rewrites each `src` to `imageDir/imageN.ext` and returns the bytes on `ConvertResult.images` (`{ path, contentType, bytes }`). New `imageDir` option (default `'images'`) and a content-type→extension map.
- **CLI** — `--image-dir <dir>` writes the files and emits relative `![](dir/imageN.ext)` links. Documented caveat: links resolve relative to wherever you redirect the `.md`.
- **Web** — a **Download .zip** button (shown only when a doc has images) re-runs conversion in extract mode and bundles `document.md` + `images/` via the already-bundled JSZip. The preview / Copy / Download-.md stay inline base64 so images still render in-page. New `downloadZip`/`downloadedZip` strings across all 7 locales.

## Verification

- `npx tsc` clean; `npm test` → **209/209** (incl. new extract, CLI `--image-dir`, and content-type→ext-map tests); coverage above threshold.
- `npm run build:site` builds all 9 locale pages, i18n parity + checks pass; `npm run lint` clean.
- Sanity-checked the web sink: JSZip produces a valid `document.md` + `images/image1.png` archive with the relative link intact.

## Notes for review

- The two web mediums intentionally carry different Markdown: Copy/​.md = self-contained base64; .zip = relative links + files.
- **EMF/WMF** are extracted as bytes but browsers can't render them and Mammoth won't transcode — noted as a known limitation, out of scope.
- The 6 non-English button strings reuse each locale's existing "Downloaded" term + a `.zip` label — worth a native-speaker glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)