### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2026-07-30
+
+### Changed
+
+- **Numbered lists now stay numbered (`1.`/`2.`/`3.`) by default** instead of
+  being converted to bullet lists — across the library, the CLI, and the web
+  app. This changes the Markdown produced for any document containing ordered
+  lists. Opt back into the classic bullet behavior with
+  `{ numberedLists: 'bullets' }` (library) or `--bullet-lists` (CLI).
+
+### Added
+
+- **Extract images to files.** The new `images: 'extract'` mode replaces
+  Mammoth's inline base64 with relative `![](images/imageN.ext)` links and
+  returns the image bytes on `ConvertResult.images` (via `convertWithWarnings`).
+  A new `imageDir` option (default `'images'`) sets the link/path prefix.
+  - CLI: `--image-dir <dir>` writes the extracted files and links them
+    relatively. Links resolve relative to wherever you save the Markdown.
+  - Web: documents with images gain a **Download .zip** button that bundles the
+    Markdown plus an `images/` folder (the on-screen preview, Copy, and
+    Download .md keep inline base64 so images still render in place).
+- **Preserve underline.** `{ underline: 'preserve' }` (library) or `--underline`
+  (CLI) keeps underlined text as inline `<u>` tags. Underline remains dropped by
+  default, matching Mammoth's default (underlines are easily confused with
+  links).
+
+### Documentation
+
+- Documented the `images`, `imageDir`, `numberedLists`, and `underline` options
+  for both the library and the CLI.
+- Corrected the docs and web UI: **superscript and subscript are preserved** as
+  inline `<sup>`/`<sub>` tags. This was already the case in 0.2.0 — only the
+  documentation, which previously listed them as unsupported, was wrong.
+
+[0.3.0]: https://github.com/benbalter/word-to-markdown-js/releases/tag/v0.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,8 +104,8 @@ Because npm's UI only lets you configure a trusted publisher on a package that a
 
 ### Cutting a release
 
-1. Bump `version` in `package.json` (e.g. `0.1.0` → `0.1.1`) and merge it to `main`.
-2. Create a GitHub Release whose tag matches the new version, prefixed with `v` (e.g. `v0.1.1`). The workflow verifies the tag matches `package.json` and fails the publish if they drift.
+1. Bump `version` in `package.json` (e.g. `0.1.0` → `0.1.1`), add a matching entry to [`CHANGELOG.md`](CHANGELOG.md), and merge both to `main`.
+2. Create a GitHub Release whose tag matches the new version, prefixed with `v` (e.g. `v0.1.1`), using the CHANGELOG entry as the release notes. The workflow verifies the tag matches `package.json` and fails the publish if they drift.
 3. The workflow builds, tests, and runs `npm publish`, authenticating via OIDC.
 
 ## Code of conduct

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-to-markdown",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Convert Word documents to beautiful Markdown.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Release-prep for **0.3.0**: bumps `package.json` (0.2.0 → 0.3.0) and adds a `CHANGELOG.md` (Keep a Changelog format) covering everything merged since 0.2.0 (PRs #181 and #182).

### After merge — cut the release
Per [CONTRIBUTING → Cutting a release](CONTRIBUTING.md): create a GitHub Release tagged **`v0.3.0`** using the CHANGELOG entry as the notes. The `release.yml` workflow verifies the tag matches `package.json` and publishes to npm via OIDC.

### Highlights (see CHANGELOG.md for the full entry)
- **Changed:** numbered lists now stay numbered (`1./2./3.`) by default — output changes for docs with ordered lists; opt out with `numberedLists: 'bullets'` / `--bullet-lists`.
- **Added:** extract images to files (`images: 'extract'`, `--image-dir`, web **Download .zip**); preserve underline (`underline: 'preserve'` / `--underline`).
- **Docs:** documented the new options; clarified that superscript/subscript were already preserved (docs were wrong, not the behavior).

Also updates CONTRIBUTING's release steps to keep the CHANGELOG in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)