### PR TITLE
ci: hold TypeScript at v6 in Renovate (TS 7 not yet supported)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>benbalter/renovate-config:instant"]
+  "extends": ["github>benbalter/renovate-config:instant"],
+  "packageRules": [
+    {
+      "description": "Hold TypeScript at v6: TS 7 (the native/Go compiler) is not yet supported by @astrojs/check (peer caps at ^6), ts-jest (<7), or typescript-eslint (<6.1). `astro check` crashes under TS 7 via @volar/kit. Re-enable once the toolchain adds TS 7 peer support.",
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## What & why

The `CI` workflow was failing on the `renovate/typescript-7.x` branch (PR #216). `main` itself was and is **green** — this only affected that Renovate branch.

**Immediate cause:** PR #216 bumped `typescript` to `^7` in `package.json` but did not regenerate `package-lock.json`, so `npm ci` failed in CI (`Missing ... from lock file`).

**Deeper cause (verified locally):** regenerating the lockfile and building showed TypeScript 7 (the native/Go compiler) is not yet supported by this repo's toolchain:

- `tsc` (`build:js`) compiles fine under 7.0.2.
- `astro check` crashes via `@astrojs/language-server` / `@volar/kit` (`Cannot read properties of undefined (reading 'fileExists')`). `@astrojs/check` caps its TS peer at `^6`, and `0.9.10` is already the latest release.
- `ts-jest` caps TS at `<7`; `typescript-eslint` at `<6.1`.

This is the "genuinely breaking / not yet supportable" case. Rather than pin in `package.json` (already `^6.0.3`, i.e. `<7`), this disables TypeScript **major** updates in the repo's `renovate.json` so Renovate stops reopening the broken PR. Revisit once the toolchain adds TS 7 peer support.

## Changes

- `renovate.json`: add a `packageRules` entry disabling `typescript` major updates, with a `description` explaining why. Validated with `renovate-config-validator` (config validated successfully).

## Follow-ups (not done here)

- Close superseded PR #216 (Renovate should abandon it once the major is disabled).
- PR #214 (eslint-plugin-jest) failed on a transient `npm audit` `Service Unavailable` (503) during the blocking critical-audit step — infra flake; a re-run clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)